### PR TITLE
feat(frontend): prefix subtask logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+frontend/utils/__tmp__/

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -5,3 +5,4 @@
 | --------------------------------- | --------------------------- | ---------- | ----------- | -------------------------------------------------------------- | ---------- | --------- |
 | Python task logger utilities | context                   | ✅ Done        | Codex       | python port of go utilities | 2025-07-10 | 2025-07-10 |
 | Table-driven tests for task_logger | context                   | ✅ Done        | Codex       | added pytest table-driven tests | 2025-07-10 | 2025-07-10 |
+| Prefix subtasks in appendTaskLog | context                   | ✅ Done        | Codex       | ts logger with parentTaskName | 2025-07-10 | 2025-07-10 |

--- a/frontend/utils/taskLogger.test.ts
+++ b/frontend/utils/taskLogger.test.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+let appendTaskLog: typeof import("./taskLogger").appendTaskLog;
+
+const tmp = path.join(__dirname, "__tmp__");
+
+beforeEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  fs.mkdirSync(path.join(tmp, "frontend"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmp, "frontend", "backlog.md"),
+    "### Codex Task: Sample\n",
+  );
+  process.env.BASE_DIR = tmp;
+  jest.resetModules();
+  ({ appendTaskLog } = require("./taskLogger"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  delete process.env.BASE_DIR;
+});
+
+test("prefixes task with parent name", async () => {
+  await appendTaskLog(
+    {
+      taskName: "Child",
+      layers: "context",
+      status: "✅ Done",
+      assignedTo: "Codex",
+      notes: "notes",
+    },
+    "Parent",
+  );
+  const logPath = path.join(tmp, "frontend", "task_log.md");
+  const content = fs.readFileSync(logPath, "utf8");
+  expect(content).toContain("Parent – Child");
+});
+
+test("cleanBacklog removes prefixed tasks", async () => {
+  const backlogPath = path.join(tmp, "frontend", "backlog.md");
+  await appendTaskLog(
+    {
+      taskName: "Part1",
+      layers: "context",
+      status: "✅ Done",
+      assignedTo: "Codex",
+      notes: "",
+    },
+    "Sample",
+  );
+  const backlog = fs.readFileSync(backlogPath, "utf8");
+  expect(backlog.trim()).toBe("");
+});

--- a/frontend/utils/taskLogger.ts
+++ b/frontend/utils/taskLogger.ts
@@ -1,27 +1,35 @@
 // utils/taskLogger.ts
 
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
-const BASE_DIR = process.env.BASE_DIR || ''; // Optional override for tests
-const TASK_LOG_FILE = 'frontend/task_log.md';
-const BACKLOG_FILE = 'frontend/backlog.md';
+const BASE_DIR = process.env.BASE_DIR || ""; // Optional override for tests
+const TASK_LOG_FILE = "frontend/task_log.md";
+const BACKLOG_FILE = "frontend/backlog.md";
 
 export interface TaskLogEntry {
   taskName: string;
   layers: string;
-  status: '✅ Done' | '⏳ In Progress' | '❌ Dropped';
+  status: "✅ Done" | "⏳ In Progress" | "❌ Dropped";
   assignedTo: string;
   notes: string;
 }
 
-export async function appendTaskLog(entry: TaskLogEntry): Promise<void> {
-  if (await hasDuplicateTask(entry.taskName)) {
-    throw new Error(`Duplicate task detected: ${entry.taskName}`);
+export async function appendTaskLog(
+  entry: TaskLogEntry,
+  parentTaskName?: string,
+): Promise<void> {
+  let taskName = entry.taskName;
+  if (parentTaskName && !taskName.startsWith(`${parentTaskName} – `)) {
+    taskName = `${parentTaskName} – ${taskName}`;
+  }
+
+  if (await hasDuplicateTask(taskName)) {
+    throw new Error(`Duplicate task detected: ${taskName}`);
   }
 
   const logPath = path.join(BASE_DIR, TASK_LOG_FILE);
-  const row = `| ${entry.taskName.padEnd(25)} | ${entry.layers.padEnd(25)} | ${entry.status.padEnd(13)} | ${entry.assignedTo.padEnd(11)} | ${entry.notes} |\n`;
+  const row = `| ${taskName.padEnd(25)} | ${entry.layers.padEnd(25)} | ${entry.status.padEnd(13)} | ${entry.assignedTo.padEnd(11)} | ${entry.notes} |\n`;
 
   await fs.promises.appendFile(logPath, row);
   await cleanBacklog();
@@ -30,7 +38,7 @@ export async function appendTaskLog(entry: TaskLogEntry): Promise<void> {
 async function hasDuplicateTask(taskName: string): Promise<boolean> {
   const logPath = path.join(BASE_DIR, TASK_LOG_FILE);
   try {
-    const content = await fs.promises.readFile(logPath, 'utf8');
+    const content = await fs.promises.readFile(logPath, "utf8");
     return content.includes(`| ${taskName} `);
   } catch {
     return false;
@@ -39,9 +47,19 @@ async function hasDuplicateTask(taskName: string): Promise<boolean> {
 
 async function cleanBacklog(): Promise<void> {
   const doneTasks = await parseDoneTasks();
+  const doneNormalized = new Set<string>();
+  for (const name of doneTasks) {
+    doneNormalized.add(name);
+    if (name.includes("–")) {
+      const trimmed = name.split("–", 1)[0].trim();
+      if (trimmed) {
+        doneNormalized.add(trimmed);
+      }
+    }
+  }
   const backlogPath = path.join(BASE_DIR, BACKLOG_FILE);
-  const content = await fs.promises.readFile(backlogPath, 'utf8');
-  const lines = content.split('\n');
+  const content = await fs.promises.readFile(backlogPath, "utf8");
+  const lines = content.split("\n");
   const result: string[] = [];
 
   let skip = false;
@@ -50,15 +68,15 @@ async function cleanBacklog(): Promise<void> {
   for (const line of lines) {
     const trimmed = line.trim();
     if (headingRegex.test(trimmed)) {
-      const idx = trimmed.toLowerCase().indexOf('codex task:');
-      const taskName = trimmed.slice(idx + 'codex task:'.length).trim();
-      skip = doneTasks.has(taskName);
+      const idx = trimmed.toLowerCase().indexOf("codex task:");
+      const taskName = trimmed.slice(idx + "codex task:".length).trim();
+      skip = doneNormalized.has(taskName);
       if (skip) continue;
     }
     if (!skip) result.push(line);
   }
 
-  const cleaned = result.join('\n') + (content.endsWith('\n') ? '\n' : '');
+  const cleaned = result.join("\n") + (content.endsWith("\n") ? "\n" : "");
   if (cleaned !== content) {
     await fs.promises.writeFile(backlogPath, cleaned);
   }
@@ -69,13 +87,13 @@ async function parseDoneTasks(): Promise<Set<string>> {
   const tasks = new Set<string>();
 
   try {
-    const content = await fs.promises.readFile(logPath, 'utf8');
-    const lines = content.split('\n');
+    const content = await fs.promises.readFile(logPath, "utf8");
+    const lines = content.split("\n");
 
     for (const line of lines) {
-      const fields = line.split('|').map(f => f.trim());
+      const fields = line.split("|").map((f) => f.trim());
       if (fields.length < 5) continue;
-      if (fields[3] === '✅ Done') {
+      if (fields[3] === "✅ Done") {
         tasks.add(fields[1]);
       }
     }
@@ -85,4 +103,3 @@ async function parseDoneTasks(): Promise<Set<string>> {
 
   return tasks;
 }
-

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const { createDefaultPreset } = require("ts-jest");
+
+const tsJestTransformCfg = createDefaultPreset().transform;
+
+/** @type {import("jest").Config} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    ...tsJestTransformCfg,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "xls-to-pdf-ma",
+  "version": "1.0.0",
+  "description": "This local web app transforms raw `.xls` flight schedules into **fully editable PDF command sheets** for airline operations — covering both **Pré-commandes** (J+2) and **Commandes Définitives** (J+1), with modes for **Salon** and **Prestations à Bord**.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.0.4",
+    "ts-jest": "^29.4.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["frontend/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- enhance appendTaskLog to support parentTaskName prefixing
- cleanBacklog normalizes done tasks when removing backlog items
- add Jest tests for utils
- add minimal Node tooling for frontend utilities
- log completion in codex_task_tracker

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686fed16fd8c832993ddc0060ad3c466