### PR TITLE
feat(repo): add XLS parser

### DIFF
--- a/backend/repository/xls_parser.py
+++ b/backend/repository/xls_parser.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import BinaryIO
+
+import pandas as pd
+
+REQUIRED_COLUMNS = ["Num Vol", "Départ", "Arrivée", "Imma", "SD LOC", "SA LOC"]
+
+
+def parse_and_filter_xls(file_stream: BinaryIO, mode: str, today: date) -> list[dict]:
+    """Load XLS stream and return rows matching the target date."""
+    df = pd.read_excel(file_stream)
+
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing column: {missing[0]}")
+
+    if mode == "commandes":
+        target = today + timedelta(days=1)
+    elif mode == "precommandes":
+        target = today + timedelta(days=2)
+    else:
+        raise ValueError("Invalid mode")
+
+    df["SD LOC"] = pd.to_datetime(df["SD LOC"], errors="coerce")
+    df["SA LOC"] = pd.to_datetime(df["SA LOC"], errors="coerce")
+
+    filtered = df[df["SD LOC"].dt.date == target]
+
+    result = []
+    for _, row in filtered.iterrows():
+        result.append(
+            {
+                "num_vol": row["Num Vol"],
+                "depart": row["Départ"],
+                "arrivee": row["Arrivée"],
+                "imma": row["Imma"],
+                "sd_loc": row["SD LOC"],
+                "sa_loc": row["SA LOC"],
+            }
+        )
+    return result

--- a/backend/tests/test_xls_parser.py
+++ b/backend/tests/test_xls_parser.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from importlib import util
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+MODULE_PATH = Path(__file__).parents[1] / "repository" / "xls_parser.py"
+spec = util.spec_from_file_location("xls_parser", MODULE_PATH)
+assert spec and spec.loader
+xls_parser: Any = util.module_from_spec(spec)
+spec.loader.exec_module(xls_parser)  # type: ignore[call-arg]
+parse_and_filter_xls = xls_parser.parse_and_filter_xls
+
+
+def _make_xls(rows: list[dict]) -> BytesIO:
+    df = pd.DataFrame(rows)
+    buf = BytesIO()
+    df.to_excel(buf, index=False, engine="openpyxl")
+    buf.seek(0)
+    return buf
+
+
+def test_parse_commandes() -> None:
+    today = date(2025, 7, 10)
+    rows = [
+        {
+            "Num Vol": "AF1",
+            "Départ": "CDG",
+            "Arrivée": "JFK",
+            "Imma": "F-1",
+            "SD LOC": datetime(2025, 7, 11, 8, 0),
+            "SA LOC": datetime(2025, 7, 11, 12, 0),
+        },
+        {
+            "Num Vol": "AF2",
+            "Départ": "CDG",
+            "Arrivée": "NRT",
+            "Imma": "F-2",
+            "SD LOC": datetime(2025, 7, 12, 8, 0),
+            "SA LOC": datetime(2025, 7, 12, 12, 0),
+        },
+    ]
+    file_obj = _make_xls(rows)
+    result = parse_and_filter_xls(file_obj, "commandes", today)
+    assert len(result) == 1
+    assert result[0]["num_vol"] == "AF1"
+
+
+def test_parse_precommandes() -> None:
+    today = date(2025, 7, 10)
+    rows = [
+        {
+            "Num Vol": "AF1",
+            "Départ": "CDG",
+            "Arrivée": "JFK",
+            "Imma": "F-1",
+            "SD LOC": datetime(2025, 7, 11, 8, 0),
+            "SA LOC": datetime(2025, 7, 11, 12, 0),
+        },
+        {
+            "Num Vol": "AF2",
+            "Départ": "CDG",
+            "Arrivée": "NRT",
+            "Imma": "F-2",
+            "SD LOC": datetime(2025, 7, 12, 8, 0),
+            "SA LOC": datetime(2025, 7, 12, 12, 0),
+        },
+    ]
+    file_obj = _make_xls(rows)
+    result = parse_and_filter_xls(file_obj, "precommandes", today)
+    assert len(result) == 1
+    assert result[0]["num_vol"] == "AF2"
+
+
+def test_missing_column_error() -> None:
+    today = date(2025, 7, 10)
+    rows = [
+        {
+            "Num Vol": "AF1",
+            "Départ": "CDG",
+            "Arrivée": "JFK",
+            # Missing Imma column
+            "SD LOC": datetime(2025, 7, 11, 8, 0),
+            "SA LOC": datetime(2025, 7, 11, 12, 0),
+        }
+    ]
+    file_obj = _make_xls(rows)
+    with pytest.raises(ValueError, match="Missing column: Imma"):
+        parse_and_filter_xls(file_obj, "commandes", today)

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -8,3 +8,4 @@
 | Prefix subtasks in appendTaskLog | context                   | ✅ Done        | Codex       | ts logger with parentTaskName | 2025-07-10 | 2025-07-10 |
 | Create backend folder structure | context                   | ✅ Done        | Codex       | added delivery/usecase/repository directories | 2025-07-10 | 2025-07-10 |
 | Create backend requirements file | context                   | ✅ Done        | Codex       | added requirements.txt and docs | 2025-07-10 | 2025-07-10 |
+| ParseAndFilterXLS()       | repository                | ✅ Done        | Codex       | added parser function and tests | 2025-07-10 | 2025-07-10 |


### PR DESCRIPTION
## Summary
- implement `parse_and_filter_xls` for loading Excel files and filtering by mode
- cover repository parser with unit tests
- log task completion in tracker

## Testing
- `ruff check backend/tests/test_xls_parser.py backend/repository/xls_parser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff953db4883299a0537850f015681