### PR TITLE
fix(frontend): update tracker logging

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -11,3 +11,4 @@
 | ParseAndFilterXLS()       | usecase                   | ✅ Done        | Codex       | implemented parser in backend/repository/xls_parser.py | 2025-07-10 | 2025-07-10 |
 | /process endpoint         | delivery                  | ✅ Done        | Codex       | implemented FastAPI route | 2025-07-10 | 2025-07-10 |
 | Upload XLS - UploadBox    | ui                        | ✅ Done        | Codex       | initial implementation | 2025-07-11 | 2025-07-11 |
+| Update frontend task logger | context                   | ✅ Done        | Codex       | switched to codex_task_tracker.md | 2025-07-11 | 2025-07-11 |

--- a/frontend/components/UploadBox.test.tsx
+++ b/frontend/components/UploadBox.test.tsx
@@ -1,9 +1,14 @@
 /** @jest-environment jsdom */
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { UploadBox } from "./UploadBox";
 
-function createFile(name: string, type = "application/vnd.ms-excel", size = 1000) {
+function createFile(
+  name: string,
+  type = "application/vnd.ms-excel",
+  size = 1000,
+) {
   const file = new File(["data"], name, { type });
   Object.defineProperty(file, "size", { value: size });
   return file;
@@ -15,7 +20,9 @@ test("rejects wrong file types", () => {
   const input = screen.getByTestId("file-input");
   const file = createFile("bad.txt", "text/plain");
   fireEvent.change(input, { target: { files: [file] } });
-  expect(screen.getByRole("alert")).toHaveTextContent("Only .xls files are allowed");
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    "Only .xls files are allowed",
+  );
   expect(onUpload).not.toHaveBeenCalled();
 });
 

--- a/frontend/task_log.md
+++ b/frontend/task_log.md
@@ -1,1 +1,0 @@
-| Upload XLS - UploadBox    | ui                        | ✅ Done        | Codex       | initial implementation |

--- a/frontend/utils/taskLogger.test.ts
+++ b/frontend/utils/taskLogger.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-let appendTaskLog: typeof import("./taskLogger").appendTaskLog;
+let updateTaskTracker: typeof import("./taskLogger").updateTaskTracker;
 
 const tmp = path.join(__dirname, "__tmp__");
 
@@ -13,7 +13,7 @@ beforeEach(() => {
   );
   process.env.BASE_DIR = tmp;
   jest.resetModules();
-  ({ appendTaskLog } = require("./taskLogger"));
+  ({ updateTaskTracker } = require("./taskLogger"));
 });
 
 afterEach(() => {
@@ -22,7 +22,7 @@ afterEach(() => {
 });
 
 test("prefixes task with parent name", async () => {
-  await appendTaskLog(
+  await updateTaskTracker(
     {
       taskName: "Child",
       layers: "context",
@@ -32,14 +32,14 @@ test("prefixes task with parent name", async () => {
     },
     "Parent",
   );
-  const logPath = path.join(tmp, "frontend", "task_log.md");
+  const logPath = path.join(tmp, "codex_task_tracker.md");
   const content = fs.readFileSync(logPath, "utf8");
   expect(content).toContain("Parent – Child");
 });
 
 test("cleanBacklog removes prefixed tasks", async () => {
   const backlogPath = path.join(tmp, "frontend", "backlog.md");
-  await appendTaskLog(
+  await updateTaskTracker(
     {
       taskName: "Part1",
       layers: "context",

--- a/frontend/utils/taskLogger.ts
+++ b/frontend/utils/taskLogger.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 
 const BASE_DIR = process.env.BASE_DIR || ""; // Optional override for tests
-const TASK_LOG_FILE = "frontend/task_log.md";
+const TASK_LOG_FILE = "codex_task_tracker.md";
 const BACKLOG_FILE = "frontend/backlog.md";
 
 export interface TaskLogEntry {
@@ -15,7 +15,7 @@ export interface TaskLogEntry {
   notes: string;
 }
 
-export async function appendTaskLog(
+export async function updateTaskTracker(
   entry: TaskLogEntry,
   parentTaskName?: string,
 ): Promise<void> {
@@ -29,7 +29,8 @@ export async function appendTaskLog(
   }
 
   const logPath = path.join(BASE_DIR, TASK_LOG_FILE);
-  const row = `| ${taskName.padEnd(25)} | ${entry.layers.padEnd(25)} | ${entry.status.padEnd(13)} | ${entry.assignedTo.padEnd(11)} | ${entry.notes} |\n`;
+  const now = new Date().toISOString().slice(0, 10);
+  const row = `| ${taskName.padEnd(25)} | ${entry.layers.padEnd(25)} | ${entry.status.padEnd(13)} | ${entry.assignedTo.padEnd(11)} | ${entry.notes} | ${now} | ${now} |\n`;
 
   await fs.promises.appendFile(logPath, row);
   await cleanBacklog();
@@ -92,7 +93,7 @@ async function parseDoneTasks(): Promise<Set<string>> {
 
     for (const line of lines) {
       const fields = line.split("|").map((f) => f.trim());
-      if (fields.length < 5) continue;
+      if (fields.length < 7) continue;
       if (fields[3] === "✅ Done") {
         tasks.add(fields[1]);
       }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,13 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
+    "@types/react": "^19.1.8",
     "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
+    "react": "^19.1.0",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "jsx": "react"
   },
   "include": ["frontend/**/*.ts", "frontend/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary
- track frontend tasks in `codex_task_tracker.md`
- add created/updated dates to task logger utility
- update tests for new tracker behaviour
- include jest-dom setup and jsx config so tests pass

## Testing
- `npx prettier -w frontend/utils/taskLogger.ts frontend/utils/taskLogger.test.ts frontend/components/UploadBox.test.tsx tsconfig.json package.json`
- `npx eslint frontend/utils/taskLogger.ts frontend/utils/taskLogger.test.ts frontend/components/UploadBox.test.tsx` *(fails: ESLint couldn't find a config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870de2b49fc8329b7d9a5ca9c5d46f2