### PR TITLE
feat(frontend): add ModeSelector component

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -13,3 +13,4 @@
 | Upload XLS - UploadBox    | ui                        | ✅ Done        | Codex       | initial implementation | 2025-07-11 | 2025-07-11 |
 | Update frontend task logger | context                   | ✅ Done        | Codex       | switched to codex_task_tracker.md | 2025-07-11 | 2025-07-11 |
 | Add jest-environment-jsdom | context                   | ✅ Done        | Codex       | added dev dependency | 2025-07-11 | 2025-07-11 |
+| Mode/Category Toggle - ModeSelector | ui                        | ✅ Done        | Codex       | implemented ModeSelector with tests | 2025-07-11 | 2025-07-11 |

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -2,20 +2,6 @@
 
 ## ✅ Epic: Flight File Ingestion & Filtering
 
-### 💻 Codex Task: Mode/Category Toggle - ModeSelector
-🧭 Context: frontend
-📁 Platform: web
-🎯 Objective: User selects between 2 modes and 2 categories
-🧩 Specs:
-* Props: `mode`, `category`, `onChange(mode, category)`
-* UI Design: Tailwind toggle buttons
-* Behavior: Active states toggle on click
-🧪 Tests:
-* Click toggles mode/category
-* Callback sends correct values
-
---------------------------------
-
 ### 💻 Codex Task: Parse XLS Hook - useProcessXLS()
 🧭 Context: frontend
 📁 Platform: web
@@ -127,4 +113,5 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 

--- a/frontend/components/ModeSelector.test.tsx
+++ b/frontend/components/ModeSelector.test.tsx
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ModeSelector } from "./ModeSelector";
+
+test("clicking mode button triggers onChange", () => {
+  const handleChange = jest.fn();
+  render(
+    <ModeSelector
+      mode="precommandes"
+      category="salon"
+      onChange={handleChange}
+    />,
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: /Commandes Définitives/i }),
+  );
+  expect(handleChange).toHaveBeenCalledWith("commandes", "salon");
+});
+
+test("clicking category button triggers onChange", () => {
+  const handleChange = jest.fn();
+  render(
+    <ModeSelector
+      mode="precommandes"
+      category="salon"
+      onChange={handleChange}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /Prestations à Bord/i }));
+  expect(handleChange).toHaveBeenCalledWith("precommandes", "prestations");
+});
+
+test("active classes match props", () => {
+  render(
+    <ModeSelector
+      mode="commandes"
+      category="prestations"
+      onChange={() => {}}
+    />,
+  );
+  const commandes = screen.getByRole("button", {
+    name: /Commandes Définitives/i,
+  });
+  const prestations = screen.getByRole("button", {
+    name: /Prestations à Bord/i,
+  });
+  expect(commandes.className).toMatch(/bg-blue-600/);
+  expect(prestations.className).toMatch(/bg-blue-600/);
+});

--- a/frontend/components/ModeSelector.tsx
+++ b/frontend/components/ModeSelector.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+export type Mode = "precommandes" | "commandes";
+export type Category = "salon" | "prestations";
+
+export interface ModeSelectorProps {
+  mode: Mode;
+  category: Category;
+  onChange: (mode: Mode, category: Category) => void;
+}
+
+export const ModeSelector: React.FC<ModeSelectorProps> = ({
+  mode,
+  category,
+  onChange,
+}) => {
+  const handleMode = (next: Mode) => () => {
+    if (next !== mode) {
+      onChange(next, category);
+    }
+  };
+
+  const handleCategory = (next: Category) => () => {
+    if (next !== category) {
+      onChange(mode, next);
+    }
+  };
+
+  const base = "px-4 py-2 rounded";
+  const active = "bg-blue-600 text-white";
+  const inactive = "bg-gray-200";
+
+  return (
+    <div>
+      <div role="group" aria-label="mode" className="flex space-x-2 mb-2">
+        <button
+          type="button"
+          className={`${base} ${mode === "precommandes" ? active : inactive}`}
+          onClick={handleMode("precommandes")}
+        >
+          Pré-commandes
+        </button>
+        <button
+          type="button"
+          className={`${base} ${mode === "commandes" ? active : inactive}`}
+          onClick={handleMode("commandes")}
+        >
+          Commandes Définitives
+        </button>
+      </div>
+      <div role="group" aria-label="category" className="flex space-x-2">
+        <button
+          type="button"
+          className={`${base} ${category === "salon" ? active : inactive}`}
+          onClick={handleCategory("salon")}
+        >
+          Salon
+        </button>
+        <button
+          type="button"
+          className={`${base} ${category === "prestations" ? active : inactive}`}
+          onClick={handleCategory("prestations")}
+        >
+          Prestations à Bord
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- implement ModeSelector with mode & category toggles
- add tests for interactions and styles
- log completion in codex_task_tracker

## Testing
- `npm test`
- `npx prettier --check frontend/components/ModeSelector.tsx frontend/components/ModeSelector.test.tsx`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6870f699a37c832988bb384d51e4270e