### PR TITLE
feat(shared): add useProcessXLS hook

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -16,3 +16,4 @@
 | Mode/Category Toggle - ModeSelector | ui                        | ✅ Done        | Codex       | implemented ModeSelector with tests | 2025-07-11 | 2025-07-11 |
 | Fix root AGENT Codex Rule bullet | docs | ✅ Done        | Codex       | completed bullet text and newline | 2025-07-11 | 2025-07-11 |
 | Add openpyxl requirement  | context                   | ✅ Done        | Codex       | added openpyxl dependency and CI install step | 2025-07-11 | 2025-07-11 |
+| Parse XLS Hook - useProcessXLS() | hooks                     | ✅ Done        | Codex       | implemented useProcessXLS and tests | 2025-07-11 | 2025-07-11 |

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -2,20 +2,6 @@
 
 ## ✅ Epic: Flight File Ingestion & Filtering
 
-### 💻 Codex Task: Parse XLS Hook - useProcessXLS()
-🧭 Context: frontend
-📁 Platform: web
-🎯 Objective: Send FormData to `/process`, receive filtered flight data
-🧩 Specs:
-* Input: File, mode, category
-* Returns: `FlightRow[]` or error
-* Error boundary: 400, 500
-🧪 Tests:
-* Valid form submission → mocked JSON response
-* Failed response → error fallback
-
---------------------------------
-
 ### 💻 Codex Task: Table Renderer - FlightTable
 🧭 Context: frontend
 📁 Platform: web
@@ -141,5 +127,6 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 
 

--- a/frontend/shared/api/axios.ts
+++ b/frontend/shared/api/axios.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+import { getConfig } from "../config";
+
+const instance = axios.create({
+  baseURL: getConfig().apiBaseUrl,
+});
+
+export default instance;

--- a/frontend/shared/hooks/useProcessXLS.test.ts
+++ b/frontend/shared/hooks/useProcessXLS.test.ts
@@ -1,0 +1,40 @@
+import { useProcessXLS } from "./useProcessXLS";
+import axios from "../api/axios";
+import { FlightRow } from "../types/flight";
+
+jest.mock("../api/axios");
+
+const mockedPost = (axios as jest.Mocked<typeof axios>).post;
+
+describe("useProcessXLS", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns data on success", async () => {
+    const rows: FlightRow[] = [
+      {
+        num_vol: "AF1",
+        depart: "CDG",
+        arrivee: "LHR",
+        imma: "A320",
+        sd_loc: "A",
+        sa_loc: "B",
+      },
+    ];
+    mockedPost.mockResolvedValue({ status: 200, data: rows });
+    const processXLS = useProcessXLS();
+    const result = await processXLS(new File([], "f.xls"), "pre", "salon");
+    expect(result).toEqual(rows);
+    expect(mockedPost).toHaveBeenCalledWith("/process", expect.any(FormData));
+  });
+
+  it("throws on http error", async () => {
+    const error = new Error("bad");
+    mockedPost.mockRejectedValue(error);
+    const processXLS = useProcessXLS();
+    await expect(
+      processXLS(new File([], "f.xls"), "pre", "salon"),
+    ).rejects.toBe(error);
+  });
+});

--- a/frontend/shared/hooks/useProcessXLS.ts
+++ b/frontend/shared/hooks/useProcessXLS.ts
@@ -1,0 +1,21 @@
+import axios from "../api/axios";
+import { FlightRow } from "../types/flight";
+
+export function useProcessXLS() {
+  return async (
+    file: File,
+    mode: string,
+    category: string,
+  ): Promise<FlightRow[]> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("mode", mode);
+    formData.append("category", category);
+    try {
+      const res = await axios.post<FlightRow[]>("/process", formData);
+      return res.data;
+    } catch (err) {
+      throw err;
+    }
+  };
+}

--- a/frontend/shared/types/flight.ts
+++ b/frontend/shared/types/flight.ts
@@ -1,0 +1,8 @@
+export interface FlightRow {
+  num_vol: string;
+  depart: string;
+  arrivee: string;
+  imma: string;
+  sd_loc: string;
+  sa_loc: string;
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "react": "^19.1.0",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "axios": "^1.10.0"
   }
 }


### PR DESCRIPTION
## Summary
- implement shared axios client
- add useProcessXLS hook for uploading XLS data
- test hook success and error cases
- log completed task

## Testing
- `npm test` *(fails: Cannot find module 'safer-buffer')*

------
https://chatgpt.com/codex/tasks/task_e_6871285ee8f08329a0e3b4ccc4aef11d