### PR TITLE
Fix safer-buffer dependency for tests

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -17,3 +17,4 @@
 | Fix root AGENT Codex Rule bullet | docs | ✅ Done        | Codex       | completed bullet text and newline | 2025-07-11 | 2025-07-11 |
 | Add openpyxl requirement  | context                   | ✅ Done        | Codex       | added openpyxl dependency and CI install step | 2025-07-11 | 2025-07-11 |
 | Parse XLS Hook - useProcessXLS() | hooks                     | ✅ Done        | Codex       | implemented useProcessXLS and tests | 2025-07-11 | 2025-07-11 |
+| Fix safer-buffer dependency for npm tests | context                   | ✅ Done        | Codex       | added safer-buffer dependency | 2025-07-11 | 2025-07-11 |

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -2,18 +2,6 @@
 
 ## ✅ Epic: Flight File Ingestion & Filtering
 
-### 💻 Codex Task: Fix safer-buffer dependency for npm tests
-🧭 Context: frontend
-📁 Platform: web
-🎯 Objective: Resolve missing `safer-buffer` module error to unblock test suite execution
-🧩 Specs:
-* Ensure `safer-buffer` is installed and resolvable in test/runtime environment
-* Update `package.json` and/or Dockerfile/CI env as needed
-🧪 Tests:
-* Run `npm test` → passes without module error
-
---------------------------------
-
 ### 💻 Codex Task: Integration Test – UploadBox + ModeSelector + useProcessXLS
 🧭 Context: frontend
 📁 Platform: web
@@ -168,6 +156,7 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 
 
 

--- a/frontend/test-setup.ts
+++ b/frontend/test-setup.ts
@@ -1,0 +1,1 @@
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   transform: {
     ...tsJestTransformCfg,
   },
+  setupFiles: ["<rootDir>/frontend/test-setup.ts"],
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.8",
+    "safer-buffer": "^2.1.2",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- add `safer-buffer` dev dependency
- provide test setup to define `NEXT_PUBLIC_API_BASE_URL`
- load setup file in jest config
- update codex task tracker
- clean backlog item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68712d6243288329aa1eded366594896