### PR TITLE
feat(web): add integration test for upload flow

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -18,3 +18,4 @@
 | Add openpyxl requirement  | context                   | ✅ Done        | Codex       | added openpyxl dependency and CI install step | 2025-07-11 | 2025-07-11 |
 | Parse XLS Hook - useProcessXLS() | hooks                     | ✅ Done        | Codex       | implemented useProcessXLS and tests | 2025-07-11 | 2025-07-11 |
 | Fix safer-buffer dependency for npm tests | context                   | ✅ Done        | Codex       | added safer-buffer dependency | 2025-07-11 | 2025-07-11 |
+| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui                        | ✅ Done        | Codex       | integration test added | 2025-07-11 | 2025-07-11 |

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -2,22 +2,6 @@
 
 ## ✅ Epic: Flight File Ingestion & Filtering
 
-### 💻 Codex Task: Integration Test – UploadBox + ModeSelector + useProcessXLS
-🧭 Context: frontend
-📁 Platform: web
-🎯 Objective: Validate interaction flow from file upload + mode/category → parsed results via `useProcessXLS`
-🧩 Specs:
-* Simulate full screen state:
-  * Upload `.xls` file
-  * Select mode/category
-  * Trigger parse via hook
-* Mock `/process` backend and return valid `FlightRow[]`
-🧪 Tests:
-* Simulate valid flow → renders expected rows
-* Simulate error response → fallback UI appears
-
---------------------------------
-
 ### 💻 Codex Task: Document FlightRow structure for editor UI
 🧭 Context: shared
 📁 Platform: web
@@ -156,6 +140,7 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 
 
 

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import axios from "../shared/api/axios";
+import { ModeSelector, Mode, Category } from "./ModeSelector";
+import { UploadBox } from "./UploadBox";
+import { useProcessXLS } from "../shared/hooks/useProcessXLS";
+import { FlightRow } from "../shared/types/flight";
+
+jest.mock("../shared/api/axios");
+
+const mockedPost = (axios as jest.Mocked<typeof axios>).post;
+
+function createFile(name: string) {
+  return new File(["data"], name, { type: "application/vnd.ms-excel" });
+}
+
+const rows: FlightRow[] = [
+  {
+    num_vol: "AF1",
+    depart: "CDG",
+    arrivee: "LHR",
+    imma: "A320",
+    sd_loc: "A",
+    sa_loc: "B",
+  },
+];
+
+const TestScreen: React.FC = () => {
+  const [mode, setMode] = React.useState<Mode>("precommandes");
+  const [category, setCategory] = React.useState<Category>("salon");
+  const [data, setData] = React.useState<FlightRow[] | null>(null);
+  const [error, setError] = React.useState(false);
+  const processXLS = useProcessXLS();
+
+  const handleUpload = async (file: File) => {
+    try {
+      const res = await processXLS(file, mode, category);
+      setData(res);
+    } catch {
+      setError(true);
+    }
+  };
+
+  return (
+    <div>
+      <ModeSelector
+        mode={mode}
+        category={category}
+        onChange={(m, c) => {
+          setMode(m);
+          setCategory(c);
+        }}
+      />
+      <UploadBox onUpload={handleUpload} />
+      {data && (
+        <ul>
+          {data.map((r) => (
+            <li key={r.num_vol}>{r.num_vol}</li>
+          ))}
+        </ul>
+      )}
+      {error && <p role="alert">Failed</p>}
+    </div>
+  );
+};
+
+test("valid flow renders rows", async () => {
+  mockedPost.mockResolvedValue({ status: 200, data: rows });
+  render(<TestScreen />);
+  fireEvent.click(
+    screen.getByRole("button", { name: /Commandes Définitives/i }),
+  );
+  fireEvent.click(screen.getByRole("button", { name: /Prestations à Bord/i }));
+  const input = screen.getByTestId("file-input");
+  fireEvent.change(input, { target: { files: [createFile("test.xls")] } });
+  await waitFor(() => {
+    expect(screen.getByText("AF1")).toBeInTheDocument();
+  });
+  expect(mockedPost).toHaveBeenCalledWith("/process", expect.any(FormData));
+});
+
+test("error response shows fallback", async () => {
+  mockedPost.mockRejectedValue(new Error("bad"));
+  render(<TestScreen />);
+  const input = screen.getByTestId("file-input");
+  fireEvent.change(input, { target: { files: [createFile("test.xls")] } });
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});

--- a/frontend/shared/config.ts
+++ b/frontend/shared/config.ts
@@ -2,7 +2,7 @@
 
 type Config = {
   apiBaseUrl: string;
-  environment: 'development' | 'staging' | 'production';
+  environment: "development" | "staging" | "production";
   sentryDsn?: string;
   featureFlags?: Record<string, boolean>;
 };
@@ -20,10 +20,11 @@ export function getConfig(): Config {
   } = process.env;
 
   if (!NEXT_PUBLIC_API_BASE_URL) {
-    throw new Error('Missing NEXT_PUBLIC_API_BASE_URL in environment');
+    throw new Error("Missing NEXT_PUBLIC_API_BASE_URL in environment");
   }
 
-  const environment = NEXT_PUBLIC_ENVIRONMENT as Config['environment'] ?? 'development';
+  const environment =
+    (NEXT_PUBLIC_ENVIRONMENT as Config["environment"]) ?? "development";
   const featureFlags = parseFeatureFlags(NEXT_PUBLIC_FEATURE_FLAGS);
 
   cached = {
@@ -40,8 +41,7 @@ function parseFeatureFlags(json?: string): Record<string, boolean> | undefined {
   try {
     return json ? JSON.parse(json) : undefined;
   } catch {
-    console.warn('Invalid JSON in NEXT_PUBLIC_FEATURE_FLAGS');
+    console.warn("Invalid JSON in NEXT_PUBLIC_FEATURE_FLAGS");
     return undefined;
   }
 }
-

--- a/frontend/test-setup.ts
+++ b/frontend/test-setup.ts
@@ -1,1 +1,1 @@
-process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+process.env.NEXT_PUBLIC_API_BASE_URL = "http://localhost";

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.8",
-    "safer-buffer": "^2.1.2",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",
     "react": "^19.1.0",
+    "safer-buffer": "^2.1.2",
     "ts-jest": "^29.4.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- test integration of UploadBox, ModeSelector, and useProcessXLS
- log completion in codex_task_tracker

## Testing
- `npm test`
- `python -m pytest -q`
- `npx eslint frontend` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68713097904c8329806d0da1db5faaa3