### PR TITLE
fix(docs): clarify editable FlightRow fields

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -1,21 +1,22 @@
 🗂️ Codex Task Tracker (SDLC Phase View | Status: To do, In Progress, Done | Context: backend/frontend/... | Notes: Technical and functional documentation)
 
-
-| **Task Title**                    | **Phase**                   | **Status** | **Context** | **Notes** | **Created** | **Updated** |
-| --------------------------------- | --------------------------- | ---------- | ----------- | -------------------------------------------------------------- | ---------- | --------- |
-| Python task logger utilities | context                   | ✅ Done        | Codex       | python port of go utilities | 2025-07-10 | 2025-07-10 |
-| Table-driven tests for task_logger | context                   | ✅ Done        | Codex       | added pytest table-driven tests | 2025-07-10 | 2025-07-10 |
-| Prefix subtasks in appendTaskLog | context                   | ✅ Done        | Codex       | ts logger with parentTaskName | 2025-07-10 | 2025-07-10 |
-| Create backend folder structure | context                   | ✅ Done        | Codex       | added delivery/usecase/repository directories | 2025-07-10 | 2025-07-10 |
-| Create backend requirements file | context                   | ✅ Done        | Codex       | added requirements.txt and docs | 2025-07-10 | 2025-07-10 |
-| ParseAndFilterXLS()       | usecase                   | ✅ Done        | Codex       | implemented parser in backend/repository/xls_parser.py | 2025-07-10 | 2025-07-10 |
-| /process endpoint         | delivery                  | ✅ Done        | Codex       | implemented FastAPI route | 2025-07-10 | 2025-07-10 |
-| Upload XLS - UploadBox    | ui                        | ✅ Done        | Codex       | initial implementation | 2025-07-11 | 2025-07-11 |
-| Update frontend task logger | context                   | ✅ Done        | Codex       | switched to codex_task_tracker.md | 2025-07-11 | 2025-07-11 |
-| Add jest-environment-jsdom | context                   | ✅ Done        | Codex       | added dev dependency | 2025-07-11 | 2025-07-11 |
-| Mode/Category Toggle - ModeSelector | ui                        | ✅ Done        | Codex       | implemented ModeSelector with tests | 2025-07-11 | 2025-07-11 |
-| Fix root AGENT Codex Rule bullet | docs | ✅ Done        | Codex       | completed bullet text and newline | 2025-07-11 | 2025-07-11 |
-| Add openpyxl requirement  | context                   | ✅ Done        | Codex       | added openpyxl dependency and CI install step | 2025-07-11 | 2025-07-11 |
-| Parse XLS Hook - useProcessXLS() | hooks                     | ✅ Done        | Codex       | implemented useProcessXLS and tests | 2025-07-11 | 2025-07-11 |
-| Fix safer-buffer dependency for npm tests | context                   | ✅ Done        | Codex       | added safer-buffer dependency | 2025-07-11 | 2025-07-11 |
-| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui                        | ✅ Done        | Codex       | integration test added | 2025-07-11 | 2025-07-11 |
+| **Task Title**                                              | **Phase** | **Status** | **Context** | **Notes**                                              | **Created** | **Updated** |
+| ----------------------------------------------------------- | --------- | ---------- | ----------- | ------------------------------------------------------ | ----------- | ----------- |
+| Python task logger utilities                                | context   | ✅ Done    | Codex       | python port of go utilities                            | 2025-07-10  | 2025-07-10  |
+| Table-driven tests for task_logger                          | context   | ✅ Done    | Codex       | added pytest table-driven tests                        | 2025-07-10  | 2025-07-10  |
+| Prefix subtasks in appendTaskLog                            | context   | ✅ Done    | Codex       | ts logger with parentTaskName                          | 2025-07-10  | 2025-07-10  |
+| Create backend folder structure                             | context   | ✅ Done    | Codex       | added delivery/usecase/repository directories          | 2025-07-10  | 2025-07-10  |
+| Create backend requirements file                            | context   | ✅ Done    | Codex       | added requirements.txt and docs                        | 2025-07-10  | 2025-07-10  |
+| ParseAndFilterXLS()                                         | usecase   | ✅ Done    | Codex       | implemented parser in backend/repository/xls_parser.py | 2025-07-10  | 2025-07-10  |
+| /process endpoint                                           | delivery  | ✅ Done    | Codex       | implemented FastAPI route                              | 2025-07-10  | 2025-07-10  |
+| Upload XLS - UploadBox                                      | ui        | ✅ Done    | Codex       | initial implementation                                 | 2025-07-11  | 2025-07-11  |
+| Update frontend task logger                                 | context   | ✅ Done    | Codex       | switched to codex_task_tracker.md                      | 2025-07-11  | 2025-07-11  |
+| Add jest-environment-jsdom                                  | context   | ✅ Done    | Codex       | added dev dependency                                   | 2025-07-11  | 2025-07-11  |
+| Mode/Category Toggle - ModeSelector                         | ui        | ✅ Done    | Codex       | implemented ModeSelector with tests                    | 2025-07-11  | 2025-07-11  |
+| Fix root AGENT Codex Rule bullet                            | docs      | ✅ Done    | Codex       | completed bullet text and newline                      | 2025-07-11  | 2025-07-11  |
+| Add openpyxl requirement                                    | context   | ✅ Done    | Codex       | added openpyxl dependency and CI install step          | 2025-07-11  | 2025-07-11  |
+| Parse XLS Hook - useProcessXLS()                            | hooks     | ✅ Done    | Codex       | implemented useProcessXLS and tests                    | 2025-07-11  | 2025-07-11  |
+| Fix safer-buffer dependency for npm tests                   | context   | ✅ Done    | Codex       | added safer-buffer dependency                          | 2025-07-11  | 2025-07-11  |
+| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui        | ✅ Done    | Codex       | integration test added                                 | 2025-07-11  | 2025-07-11  |
+| Document FlightRow structure for editor UI                  | docs      | ✅ Done    | Codex       | added J/C and Y/C docs                                 | 2025-07-11  | 2025-07-11  |
+| Fix editable field definition in FlightRow TECH_SPEC        | docs      | ✅ Done    | Codex       | clarify editable j/y fields                            | 2025-07-11  | 2025-07-11  |

--- a/docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/PRD.md
+++ b/docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/PRD.md
@@ -1,0 +1,51 @@
+# 📘 PRD – Feature: FlightRow Structure Documentation
+
+## 🧩 Belongs To
+
+🧱 Epic: Flight File Ingestion & Filtering
+📂 Module: `/frontend/shared/types/flight.ts`
+
+---
+
+## 🎯 Goal
+
+Provide a reference for developers explaining how the `FlightRow` type maps to columns in the editable table. Clarify which fields are editable and how new columns should be added in future iterations.
+
+---
+
+## 👤 Users
+
+- Internal developers working on the editor UI.
+
+---
+
+## 📥 Source
+
+`FlightRow` is defined in `/frontend/shared/types/flight.ts` and returned by the backend `/process` endpoint.
+
+---
+
+## 📝 Documentation Outline
+
+1. Field list with editable vs read‑only status.
+2. Mapping of each field to table column heading.
+3. Guidance on extending the interface when backend returns extra columns.
+
+### Editable Fields
+
+- `depart`
+- `arrivee`
+- `imma`
+- `sd_loc`
+- `sa_loc`
+- `j_class`
+- `y_class`
+
+---
+
+## ✅ Acceptance Criteria
+
+- [ ] Documented mapping matches current interface.
+- [ ] Instructions cover future extension without breaking the table.
+- [ ] Inputs for `j_class` and `y_class` appear and default to `0`
+- [ ] Inputs propagate changes to `FlightRow` state

--- a/docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/TECH_SPEC.md
+++ b/docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/TECH_SPEC.md
@@ -1,0 +1,60 @@
+# 📄 TECH_SPEC – FlightRow Structure Documentation
+
+This spec explains each field of `FlightRow` and how it maps to the editable table used in the editor UI.
+
+---
+
+## 1. Interface Reference
+
+```ts
+export interface FlightRow {
+  num_vol: string;
+  depart: string;
+  arrivee: string;
+  imma: string;
+  sd_loc: string;
+  sa_loc: string;
+  j_class: number;
+  y_class: number;
+}
+```
+
+`num_vol`, `depart`, `arrivee`, `imma`, `sd_loc`, and `sa_loc` are read‑only columns.
+Only `j_class` and `y_class` are editable numeric inputs that default to `0`.
+
+---
+
+## 2. Column Mapping
+
+| Interface Field | Table Heading | Editable (Browser UI) |
+| --------------- | ------------- | --------------------- |
+| `num_vol`       | Num Vol       | No                    |
+| `depart`        | Départ        | No                    |
+| `arrivee`       | Arrivée       | No                    |
+| `imma`          | Imma          | No                    |
+| `sd_loc`        | SD LOC        | No                    |
+| `sa_loc`        | SA LOC        | No                    |
+| `j_class`       | J/C           | Yes                   |
+| `y_class`       | Y/C           | Yes                   |
+
+Only `j_class` and `y_class` are editable in the browser UI. These fields appear as numeric inputs and default to `0` when a row is created or parsed. All other values are read-only and derived from the parsed `.xls` source.
+
+---
+
+## 3. Extending the Type
+
+When the backend introduces new fields, extend the interface in `flight.ts` and update the table renderer. For optional fields, add `?` to the property. Example:
+
+```ts
+export interface FlightRow {
+  num_vol: string;
+  depart: string;
+  arrivee: string;
+  imma: string;
+  sd_loc: string;
+  sa_loc: string;
+  gate?: string; // new optional field
+}
+```
+
+Add the new column heading to `FlightTable` and ensure default values are handled in state.

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -2,19 +2,6 @@
 
 ## ✅ Epic: Flight File Ingestion & Filtering
 
-### 💻 Codex Task: Document FlightRow structure for editor UI
-🧭 Context: shared
-📁 Platform: web
-🎯 Objective: Write internal dev doc describing how `FlightRow` maps to editable table
-🧩 Specs:
-* Field mapping:
-  * `depart`, `arrivee`, `imma`, `sd_loc`, `sa_loc` → editable inputs
-  * `num_vol` → read-only
-* Describe where/how to extend the type if new fields appear
-🧪 Tests: N/A (docs only)
-
---------------------------------
-
 ### 💻 Codex Task: Table Renderer - FlightTable
 🧭 Context: frontend
 📁 Platform: web
@@ -140,6 +127,7 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 
 
 


### PR DESCRIPTION
## Summary
- clarify that only `j_class` and `y_class` are editable in FlightRow
- clean up backlog entry after documentation update
- log completion in task tracker

## Testing
- `npx prettier -w docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/TECH_SPEC.md codex_task_tracker.md`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687137129b448329b733d7b4a1f67172