### PR TITLE
fix(docs): classify tracker entries

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -2,21 +2,21 @@
 
 | **Task Title**                                              | **Phase** | **Status** | **Context** | **Notes**                                              | **Created** | **Updated** |
 | ----------------------------------------------------------- | --------- | ---------- | ----------- | ------------------------------------------------------ | ----------- | ----------- |
-| Python task logger utilities                                | context   | ✅ Done    | Codex       | python port of go utilities                            | 2025-07-10  | 2025-07-10  |
-| Table-driven tests for task_logger                          | context   | ✅ Done    | Codex       | added pytest table-driven tests                        | 2025-07-10  | 2025-07-10  |
-| Prefix subtasks in appendTaskLog                            | context   | ✅ Done    | Codex       | ts logger with parentTaskName                          | 2025-07-10  | 2025-07-10  |
-| Create backend folder structure                             | context   | ✅ Done    | Codex       | added delivery/usecase/repository directories          | 2025-07-10  | 2025-07-10  |
-| Create backend requirements file                            | context   | ✅ Done    | Codex       | added requirements.txt and docs                        | 2025-07-10  | 2025-07-10  |
-| ParseAndFilterXLS()                                         | usecase   | ✅ Done    | Codex       | implemented parser in backend/repository/xls_parser.py | 2025-07-10  | 2025-07-10  |
-| /process endpoint                                           | delivery  | ✅ Done    | Codex       | implemented FastAPI route                              | 2025-07-10  | 2025-07-10  |
-| Upload XLS - UploadBox                                      | ui        | ✅ Done    | Codex       | initial implementation                                 | 2025-07-11  | 2025-07-11  |
-| Update frontend task logger                                 | context   | ✅ Done    | Codex       | switched to codex_task_tracker.md                      | 2025-07-11  | 2025-07-11  |
-| Add jest-environment-jsdom                                  | context   | ✅ Done    | Codex       | added dev dependency                                   | 2025-07-11  | 2025-07-11  |
-| Mode/Category Toggle - ModeSelector                         | ui        | ✅ Done    | Codex       | implemented ModeSelector with tests                    | 2025-07-11  | 2025-07-11  |
-| Fix root AGENT Codex Rule bullet                            | docs      | ✅ Done    | Codex       | completed bullet text and newline                      | 2025-07-11  | 2025-07-11  |
-| Add openpyxl requirement                                    | context   | ✅ Done    | Codex       | added openpyxl dependency and CI install step          | 2025-07-11  | 2025-07-11  |
-| Parse XLS Hook - useProcessXLS()                            | hooks     | ✅ Done    | Codex       | implemented useProcessXLS and tests                    | 2025-07-11  | 2025-07-11  |
-| Fix safer-buffer dependency for npm tests                   | context   | ✅ Done    | Codex       | added safer-buffer dependency                          | 2025-07-11  | 2025-07-11  |
-| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui        | ✅ Done    | Codex       | integration test added                                 | 2025-07-11  | 2025-07-11  |
-| Document FlightRow structure for editor UI                  | docs      | ✅ Done    | Codex       | added J/C and Y/C docs                                 | 2025-07-11  | 2025-07-11  |
-| Fix editable field definition in FlightRow TECH_SPEC        | docs      | ✅ Done    | Codex       | clarify editable j/y fields                            | 2025-07-11  | 2025-07-11  |
+| Python task logger utilities | context                   | ✅ Done        | backend     | python port of go utilities | 2025-07-10 | 2025-07-11 |
+| Table-driven tests for task_logger | context                   | ✅ Done        | backend     | added pytest table-driven tests | 2025-07-10 | 2025-07-11 |
+| Create backend folder structure | context                   | ✅ Done        | backend     | added delivery/usecase/repository directories | 2025-07-10 | 2025-07-11 |
+| Create backend requirements file | context                   | ✅ Done        | backend     | added requirements.txt and docs | 2025-07-10 | 2025-07-11 |
+| ParseAndFilterXLS()       | usecase                   | ✅ Done        | backend     | implemented parser in backend/repository/xls_parser.py | 2025-07-10 | 2025-07-11 |
+| /process endpoint         | delivery                  | ✅ Done        | backend     | implemented FastAPI route | 2025-07-10 | 2025-07-11 |
+| Fix root AGENT Codex Rule bullet | docs                      | ✅ Done        | backend     | completed bullet text and newline | 2025-07-11 | 2025-07-11 |
+| Add openpyxl requirement  | context                   | ✅ Done        | backend     | added openpyxl dependency and CI install step | 2025-07-11 | 2025-07-11 |
+| Prefix subtasks in appendTaskLog | context                   | ✅ Done        | frontend    | ts logger with parentTaskName | 2025-07-11 | 2025-07-11 |
+| Upload XLS - UploadBox    | ui                        | ✅ Done        | frontend    | initial implementation | 2025-07-11 | 2025-07-11 |
+| Update frontend task logger | context                   | ✅ Done        | frontend    | switched to codex_task_tracker.md | 2025-07-11 | 2025-07-11 |
+| Add jest-environment-jsdom | context                   | ✅ Done        | frontend    | added dev dependency | 2025-07-11 | 2025-07-11 |
+| Mode/Category Toggle - ModeSelector | ui                        | ✅ Done        | frontend    | implemented ModeSelector with tests | 2025-07-11 | 2025-07-11 |
+| Parse XLS Hook - useProcessXLS() | hooks                     | ✅ Done        | frontend    | implemented useProcessXLS and tests | 2025-07-11 | 2025-07-11 |
+| Fix safer-buffer dependency for npm tests | context                   | ✅ Done        | frontend    | added safer-buffer dependency | 2025-07-11 | 2025-07-11 |
+| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui                        | ✅ Done        | frontend    | integration test added | 2025-07-11 | 2025-07-11 |
+| Document FlightRow structure for editor UI | docs                      | ✅ Done        | frontend    | added J/C and Y/C docs | 2025-07-11 | 2025-07-11 |
+| Fix editable field definition in FlightRow TECH_SPEC | docs                      | ✅ Done        | frontend    | clarify editable j/y fields | 2025-07-11 | 2025-07-11 |


### PR DESCRIPTION
## Summary
- classify each Codex row as backend or frontend in codex_task_tracker

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest`
- `npx prettier --check "**/*.ts"`
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68714dc9073c8329ad0e7ef5b0320fef