### PR TITLE
fix(frontend): update task logger duplicate handling

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -20,3 +20,4 @@
 | Integration Test – UploadBox + ModeSelector + useProcessXLS | ui                        | ✅ Done        | frontend    | integration test added | 2025-07-11 | 2025-07-11 |
 | Document FlightRow structure for editor UI | docs                      | ✅ Done        | frontend    | added J/C and Y/C docs | 2025-07-11 | 2025-07-11 |
 | Fix editable field definition in FlightRow TECH_SPEC | docs                      | ✅ Done        | frontend    | clarify editable j/y fields | 2025-07-11 | 2025-07-11 |
+| Rewrite duplicates in updateTaskTracker | context                   | ✅ Done        | frontend    | rewrite duplicate rows and add tests | 2025-07-11 | 2025-07-11 |


### PR DESCRIPTION
## Summary
- allow updateTaskTracker to overwrite existing tasks
- test row rewriting and timestamp behavior
- log codex task for this change

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68715853a97483298184f56ae01b2aed