### PR TITLE
feat(shared): add seat class fields

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -2,22 +2,23 @@
 
 | **Task Title**                                              | **Phase** | **Status** | **Context** | **Notes**                                              | **Created** | **Updated** |
 | ----------------------------------------------------------- | --------- | ---------- | ----------- | ------------------------------------------------------ | ----------- | ----------- |
-| Python task logger utilities | context                   | ✅ Done        | backend     | python port of go utilities | 2025-07-10 | 2025-07-11 |
-| Table-driven tests for task_logger | context                   | ✅ Done        | backend     | added pytest table-driven tests | 2025-07-10 | 2025-07-11 |
-| Create backend folder structure | context                   | ✅ Done        | backend     | added delivery/usecase/repository directories | 2025-07-10 | 2025-07-11 |
-| Create backend requirements file | context                   | ✅ Done        | backend     | added requirements.txt and docs | 2025-07-10 | 2025-07-11 |
-| ParseAndFilterXLS()       | usecase                   | ✅ Done        | backend     | implemented parser in backend/repository/xls_parser.py | 2025-07-10 | 2025-07-11 |
-| /process endpoint         | delivery                  | ✅ Done        | backend     | implemented FastAPI route | 2025-07-10 | 2025-07-11 |
-| Fix root AGENT Codex Rule bullet | docs                      | ✅ Done        | backend     | completed bullet text and newline | 2025-07-11 | 2025-07-11 |
-| Add openpyxl requirement  | context                   | ✅ Done        | backend     | added openpyxl dependency and CI install step | 2025-07-11 | 2025-07-11 |
-| Prefix subtasks in appendTaskLog | context                   | ✅ Done        | frontend    | ts logger with parentTaskName | 2025-07-11 | 2025-07-11 |
-| Upload XLS - UploadBox    | ui                        | ✅ Done        | frontend    | initial implementation | 2025-07-11 | 2025-07-11 |
-| Update frontend task logger | context                   | ✅ Done        | frontend    | switched to codex_task_tracker.md | 2025-07-11 | 2025-07-11 |
-| Add jest-environment-jsdom | context                   | ✅ Done        | frontend    | added dev dependency | 2025-07-11 | 2025-07-11 |
-| Mode/Category Toggle - ModeSelector | ui                        | ✅ Done        | frontend    | implemented ModeSelector with tests | 2025-07-11 | 2025-07-11 |
-| Parse XLS Hook - useProcessXLS() | hooks                     | ✅ Done        | frontend    | implemented useProcessXLS and tests | 2025-07-11 | 2025-07-11 |
-| Fix safer-buffer dependency for npm tests | context                   | ✅ Done        | frontend    | added safer-buffer dependency | 2025-07-11 | 2025-07-11 |
-| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui                        | ✅ Done        | frontend    | integration test added | 2025-07-11 | 2025-07-11 |
-| Document FlightRow structure for editor UI | docs                      | ✅ Done        | frontend    | added J/C and Y/C docs | 2025-07-11 | 2025-07-11 |
-| Fix editable field definition in FlightRow TECH_SPEC | docs                      | ✅ Done        | frontend    | clarify editable j/y fields | 2025-07-11 | 2025-07-11 |
-| Rewrite duplicates in updateTaskTracker | context                   | ✅ Done        | frontend    | rewrite duplicate rows and add tests | 2025-07-11 | 2025-07-11 |
+| Python task logger utilities                                | context   | ✅ Done    | backend     | python port of go utilities                            | 2025-07-10  | 2025-07-11  |
+| Table-driven tests for task_logger                          | context   | ✅ Done    | backend     | added pytest table-driven tests                        | 2025-07-10  | 2025-07-11  |
+| Create backend folder structure                             | context   | ✅ Done    | backend     | added delivery/usecase/repository directories          | 2025-07-10  | 2025-07-11  |
+| Create backend requirements file                            | context   | ✅ Done    | backend     | added requirements.txt and docs                        | 2025-07-10  | 2025-07-11  |
+| ParseAndFilterXLS()                                         | usecase   | ✅ Done    | backend     | implemented parser in backend/repository/xls_parser.py | 2025-07-10  | 2025-07-11  |
+| /process endpoint                                           | delivery  | ✅ Done    | backend     | implemented FastAPI route                              | 2025-07-10  | 2025-07-11  |
+| Fix root AGENT Codex Rule bullet                            | docs      | ✅ Done    | backend     | completed bullet text and newline                      | 2025-07-11  | 2025-07-11  |
+| Add openpyxl requirement                                    | context   | ✅ Done    | backend     | added openpyxl dependency and CI install step          | 2025-07-11  | 2025-07-11  |
+| Prefix subtasks in appendTaskLog                            | context   | ✅ Done    | frontend    | ts logger with parentTaskName                          | 2025-07-11  | 2025-07-11  |
+| Upload XLS - UploadBox                                      | ui        | ✅ Done    | frontend    | initial implementation                                 | 2025-07-11  | 2025-07-11  |
+| Update frontend task logger                                 | context   | ✅ Done    | frontend    | switched to codex_task_tracker.md                      | 2025-07-11  | 2025-07-11  |
+| Add jest-environment-jsdom                                  | context   | ✅ Done    | frontend    | added dev dependency                                   | 2025-07-11  | 2025-07-11  |
+| Mode/Category Toggle - ModeSelector                         | ui        | ✅ Done    | frontend    | implemented ModeSelector with tests                    | 2025-07-11  | 2025-07-11  |
+| Parse XLS Hook - useProcessXLS()                            | hooks     | ✅ Done    | frontend    | implemented useProcessXLS and tests                    | 2025-07-11  | 2025-07-11  |
+| Fix safer-buffer dependency for npm tests                   | context   | ✅ Done    | frontend    | added safer-buffer dependency                          | 2025-07-11  | 2025-07-11  |
+| Integration Test – UploadBox + ModeSelector + useProcessXLS | ui        | ✅ Done    | frontend    | integration test added                                 | 2025-07-11  | 2025-07-11  |
+| Document FlightRow structure for editor UI                  | docs      | ✅ Done    | frontend    | added J/C and Y/C docs                                 | 2025-07-11  | 2025-07-11  |
+| Fix editable field definition in FlightRow TECH_SPEC        | docs      | ✅ Done    | frontend    | clarify editable j/y fields                            | 2025-07-11  | 2025-07-11  |
+| Rewrite duplicates in updateTaskTracker                     | context   | ✅ Done    | frontend    | rewrite duplicate rows and add tests                   | 2025-07-11  | 2025-07-11  |
+| Extend FlightRow with seat classes                          | shared    | ✅ Done    | frontend    | add j_class and y_class fields; update tests           | 2025-07-12  | 2025-07-12  |

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -24,6 +24,8 @@ const rows: FlightRow[] = [
     imma: "A320",
     sd_loc: "A",
     sa_loc: "B",
+    j_class: 0,
+    y_class: 0,
   },
 ];
 

--- a/frontend/shared/hooks/useProcessXLS.test.ts
+++ b/frontend/shared/hooks/useProcessXLS.test.ts
@@ -20,6 +20,8 @@ describe("useProcessXLS", () => {
         imma: "A320",
         sd_loc: "A",
         sa_loc: "B",
+        j_class: 0,
+        y_class: 0,
       },
     ];
     mockedPost.mockResolvedValue({ status: 200, data: rows });

--- a/frontend/shared/types/flight.ts
+++ b/frontend/shared/types/flight.ts
@@ -5,4 +5,12 @@ export interface FlightRow {
   imma: string;
   sd_loc: string;
   sa_loc: string;
+  /**
+   * Number of J class seats. Defaults to 0 when a row is created.
+   */
+  j_class: number;
+  /**
+   * Number of Y class seats. Defaults to 0 when a row is created.
+   */
+  y_class: number;
 }


### PR DESCRIPTION
## Summary
- extend `FlightRow` type with seat class fields
- update unit and integration tests to include numeric fields
- log update in task tracker

## Testing
- `npx eslint frontend` *(fails: ESLint couldn't find a configuration file)*
- `npx prettier --write frontend/shared/types/flight.ts frontend/shared/hooks/useProcessXLS.test.ts frontend/components/UploadFlow.integration.test.tsx codex_task_tracker.md`
- `npx tsc --noEmit` *(fails: cannot find module declarations)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687240f9c5008329b2617f6b39013896