### PR TITLE
Add FlightTable component

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -22,3 +22,4 @@
 | Fix editable field definition in FlightRow TECH_SPEC        | docs      | ✅ Done    | frontend    | clarify editable j/y fields                            | 2025-07-11  | 2025-07-11  |
 | Rewrite duplicates in updateTaskTracker                     | context   | ✅ Done    | frontend    | rewrite duplicate rows and add tests                   | 2025-07-11  | 2025-07-11  |
 | Extend FlightRow with seat classes                          | shared    | ✅ Done    | frontend    | add j_class and y_class fields; update tests           | 2025-07-12  | 2025-07-12  |
+| Table Renderer – FlightTable                                | ui        | ✅ Done    | frontend    | implement table component                              | 2025-07-12  | 2025-07-12  |

--- a/frontend/components/FlightTable.test.tsx
+++ b/frontend/components/FlightTable.test.tsx
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FlightTable } from "./FlightTable";
+import { FlightRow } from "../shared/types/flight";
+
+describe("FlightTable", () => {
+  const baseRow: FlightRow = {
+    num_vol: "AF1",
+    depart: "CDG",
+    arrivee: "LHR",
+    imma: "A320",
+    sd_loc: "A",
+    sa_loc: "B",
+    j_class: 1,
+    y_class: 2,
+  };
+
+  test("renders all columns", () => {
+    render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
+    expect(screen.getByText("AF1")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("1")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("2")).toBeInTheDocument();
+  });
+
+  test("only j_class and y_class are editable", () => {
+    render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
+    const inputs = screen.getAllByRole("spinbutton");
+    expect(inputs).toHaveLength(2);
+  });
+
+  test("onChange called with updated row", () => {
+    const handle = jest.fn();
+    render(<FlightTable rows={[baseRow]} onChange={handle} />);
+    const input = screen.getAllByRole("spinbutton")[0];
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 5 });
+  });
+
+  test("handles undefined numeric fields", () => {
+    const row = { ...baseRow, j_class: undefined as unknown as number };
+    render(<FlightTable rows={[row]} onChange={() => {}} />);
+    expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(0);
+  });
+
+  test("invalid input results in 0", () => {
+    const handle = jest.fn();
+    render(<FlightTable rows={[baseRow]} onChange={handle} />);
+    const input = screen.getAllByRole("spinbutton")[0];
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 0 });
+  });
+});

--- a/frontend/components/FlightTable.tsx
+++ b/frontend/components/FlightTable.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { FlightRow } from "../shared/types/flight";
+
+export interface FlightTableProps {
+  rows: FlightRow[];
+  onChange: (updatedRow: FlightRow) => void;
+}
+
+export const FlightTable: React.FC<FlightTableProps> = ({ rows, onChange }) => {
+  const handleNumberChange =
+    (field: "j_class" | "y_class", row: FlightRow) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseInt(e.target.value, 10);
+      const safeValue = Number.isNaN(value) ? 0 : value;
+      onChange({ ...row, [field]: safeValue });
+    };
+
+  return (
+    <div className="overflow-y-auto max-h-96">
+      <table className="min-w-full text-sm">
+        <thead className="sticky top-0 bg-gray-100">
+          <tr>
+            <th className="px-2 py-1 text-left">Num Vol</th>
+            <th className="px-2 py-1 text-left">Départ</th>
+            <th className="px-2 py-1 text-left">Arrivée</th>
+            <th className="px-2 py-1 text-left">Imma</th>
+            <th className="px-2 py-1 text-left">SD LOC</th>
+            <th className="px-2 py-1 text-left">SA LOC</th>
+            <th className="px-2 py-1 text-left">J/C</th>
+            <th className="px-2 py-1 text-left">Y/C</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.num_vol} className="odd:bg-white even:bg-gray-50">
+              <td className="px-2 py-1">{r.num_vol}</td>
+              <td className="px-2 py-1">{r.depart}</td>
+              <td className="px-2 py-1">{r.arrivee}</td>
+              <td className="px-2 py-1">{r.imma}</td>
+              <td className="px-2 py-1">{r.sd_loc}</td>
+              <td className="px-2 py-1">{r.sa_loc}</td>
+              <td className="px-2 py-1">
+                <input
+                  type="number"
+                  className="w-20 border rounded px-1"
+                  value={r.j_class ?? 0}
+                  onChange={handleNumberChange("j_class", r)}
+                />
+              </td>
+              <td className="px-2 py-1">
+                <input
+                  type="number"
+                  className="w-20 border rounded px-1"
+                  value={r.y_class ?? 0}
+                  onChange={handleNumberChange("y_class", r)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default FlightTable;

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -7,6 +7,7 @@ import { ModeSelector, Mode, Category } from "./ModeSelector";
 import { UploadBox } from "./UploadBox";
 import { useProcessXLS } from "../shared/hooks/useProcessXLS";
 import { FlightRow } from "../shared/types/flight";
+import { FlightTable } from "./FlightTable";
 
 jest.mock("../shared/api/axios");
 
@@ -56,13 +57,7 @@ const TestScreen: React.FC = () => {
         }}
       />
       <UploadBox onUpload={handleUpload} />
-      {data && (
-        <ul>
-          {data.map((r) => (
-            <li key={r.num_vol}>{r.num_vol}</li>
-          ))}
-        </ul>
-      )}
+      {data && <FlightTable rows={data} onChange={() => {}} />}
       {error && <p role="alert">Failed</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- implement `FlightTable` with editable seat fields
- test rendering and change events for `FlightTable`
- use `FlightTable` in integration test
- log task completion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872437bc8d88329ba714e5dc85ff669