### PR TITLE
Implement seat class input validation

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -23,3 +23,4 @@
 | Rewrite duplicates in updateTaskTracker                     | context   | ✅ Done    | frontend    | rewrite duplicate rows and add tests                   | 2025-07-11  | 2025-07-11  |
 | Extend FlightRow with seat classes                          | shared    | ✅ Done    | frontend    | add j_class and y_class fields; update tests           | 2025-07-12  | 2025-07-12  |
 | Table Renderer – FlightTable                                | ui        | ✅ Done    | frontend    | implement table component                              | 2025-07-12  | 2025-07-12  |
+| Seat Class Validation - FlightTable | ui                        | ✅ Done        | frontend    | j/y class validation 0-99 with error state | 2025-07-12 | 2025-07-12 |

--- a/docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/TECH_SPEC.md
+++ b/docs/frontend/epic/1.Flight File Ingestion and Filtering/FlightRow Structure/TECH_SPEC.md
@@ -20,7 +20,13 @@ export interface FlightRow {
 ```
 
 `num_vol`, `depart`, `arrivee`, `imma`, `sd_loc`, and `sa_loc` are read‑only columns.
-Only `j_class` and `y_class` are editable numeric inputs that default to `0`.
+Only `j_class` and `y_class` are editable. These fields use `<input type="number">` with the following validation rules:
+
+- `min` **0**
+- `max` **99**
+- `step` **1** (whole numbers only)
+
+Typing letters or decimals is blocked. Values below `0`, above `99`, or empty trigger a red border and accessible error label. The table does not propagate changes until the value is corrected.
 
 ---
 

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -2,26 +2,6 @@
 
 ## ✅ Epic: Flight File Ingestion & Filtering
 
-💻 Codex Task: Table Renderer – FlightTable  
-🧭 Context: frontend  
-📁 Platform: web  
-🎯 Objective: Render browser-based table for reviewing parsed flight data and editing seat class fields  
-🧩 Specs:
-- Props: `rows: FlightRow[]`, `onChange(updatedRow: FlightRow): void`
-- UI: Tailwind scrollable table with sticky header
-- Column behavior:
-  - **Read-only in browser UI**: Num Vol, Départ, Arrivée, Imma, SD LOC, SA LOC  
-    (these are parsed from `.xls`, may be modified in PDF output via CLI only)
-  - **Editable in browser**: J/C (`j_class`), Y/C (`y_class`)
-- Inputs: numeric type for J/C and Y/C, initialized to `0` if missing
-🧪 Tests:
-- Renders all columns with correct values and layout
-- Allows editing only J/C and Y/C fields
-- Triggers `onChange` with updated `FlightRow` on user edit
-- Handles edge cases: undefined fields, invalid input, max char length
-
---------------------------------
-
 ### 💻 Codex Task: IPC Bridge - usePythonSubprocess()
 🧭 Context: frontend
 📁 Platform: web
@@ -62,6 +42,21 @@
 🧪 Tests:
 * Render all toggle states
 * Actions tab logs changes via `onChange` handler
+
+### 💻 Codex Task: Seat Class Validation
+🧭 Context: frontend
+📁 Platform: web
+🎯 Objective: Enforce numeric validation rules for `j_class` and `y_class`
+🧩 Specs:
+* Inputs min `0`, max `99`, step `1`
+* Letters or decimals blocked
+* Negative or >99 values show error with red border
+* Invalid fields prevent update until corrected
+🧪 Tests:
+* Typing `-1`, `abc`, `100` → error highlight
+* Typing `23`, `0`, `99` → valid
+* Blur triggers validation display
+* Error clears when corrected
 
 --------------------------------
 
@@ -133,6 +128,7 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 
 
 

--- a/frontend/components/FlightTable.test.tsx
+++ b/frontend/components/FlightTable.test.tsx
@@ -44,11 +44,30 @@ describe("FlightTable", () => {
     expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(0);
   });
 
-  test("invalid input results in 0", () => {
+  test("invalid input shows error and blocks change", () => {
     const handle = jest.fn();
     render(<FlightTable rows={[baseRow]} onChange={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
     fireEvent.change(input, { target: { value: "abc" } });
-    expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 0 });
+    expect(handle).not.toHaveBeenCalled();
+    expect(input).toHaveClass("border-red-500");
+  });
+
+  test("values outside range show error", () => {
+    render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
+    const input = screen.getAllByRole("spinbutton")[0];
+    fireEvent.change(input, { target: { value: "100" } });
+    fireEvent.blur(input);
+    expect(input).toHaveClass("border-red-500");
+  });
+
+  test("valid input clears error", () => {
+    const handle = jest.fn();
+    render(<FlightTable rows={[baseRow]} onChange={handle} />);
+    const input = screen.getAllByRole("spinbutton")[0];
+    fireEvent.change(input, { target: { value: "23" } });
+    fireEvent.blur(input);
+    expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 23 });
+    expect(input).not.toHaveClass("border-red-500");
   });
 });

--- a/frontend/components/FlightTable.tsx
+++ b/frontend/components/FlightTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FlightRow } from "../shared/types/flight";
+import { useSeatClassInput } from "../shared/hooks/useSeatClassInput";
 
 export interface FlightTableProps {
   rows: FlightRow[];
@@ -7,13 +8,36 @@ export interface FlightTableProps {
 }
 
 export const FlightTable: React.FC<FlightTableProps> = ({ rows, onChange }) => {
-  const handleNumberChange =
-    (field: "j_class" | "y_class", row: FlightRow) =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = parseInt(e.target.value, 10);
-      const safeValue = Number.isNaN(value) ? 0 : value;
-      onChange({ ...row, [field]: safeValue });
-    };
+  const SeatInput: React.FC<{
+    value: number;
+    onValid: (val: number) => void;
+    label: string;
+  }> = ({ value, onValid, label }) => {
+    const { value: val, error, handleChange, handleBlur } = useSeatClassInput(
+      value,
+      onValid,
+    );
+    return (
+      <div>
+        <input
+          type="number"
+          min={0}
+          max={99}
+          step={1}
+          aria-label={label}
+          className={`w-20 border rounded px-1 ${error ? "border-red-500" : ""}`}
+          value={val}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+        {error && (
+          <span role="alert" className="text-red-600 text-xs">
+            Invalid
+          </span>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="overflow-y-auto max-h-96">
@@ -40,19 +64,17 @@ export const FlightTable: React.FC<FlightTableProps> = ({ rows, onChange }) => {
               <td className="px-2 py-1">{r.sd_loc}</td>
               <td className="px-2 py-1">{r.sa_loc}</td>
               <td className="px-2 py-1">
-                <input
-                  type="number"
-                  className="w-20 border rounded px-1"
+                <SeatInput
                   value={r.j_class ?? 0}
-                  onChange={handleNumberChange("j_class", r)}
+                  onValid={(val) => onChange({ ...r, j_class: val })}
+                  label={`J class for ${r.num_vol}`}
                 />
               </td>
               <td className="px-2 py-1">
-                <input
-                  type="number"
-                  className="w-20 border rounded px-1"
+                <SeatInput
                   value={r.y_class ?? 0}
-                  onChange={handleNumberChange("y_class", r)}
+                  onValid={(val) => onChange({ ...r, y_class: val })}
+                  label={`Y class for ${r.num_vol}`}
                 />
               </td>
             </tr>

--- a/frontend/shared/hooks/useSeatClassInput.test.ts
+++ b/frontend/shared/hooks/useSeatClassInput.test.ts
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from "@testing-library/react";
+import { useSeatClassInput } from "./useSeatClassInput";
+
+describe("useSeatClassInput", () => {
+  test("valid change passes value", () => {
+    const onValid = jest.fn();
+    const { result } = renderHook(() => useSeatClassInput(0, onValid));
+    act(() => {
+      result.current.handleChange({ target: { value: "10" } } as any);
+    });
+    expect(onValid).toHaveBeenCalledWith(10);
+    expect(result.current.error).toBe(false);
+  });
+
+  test("letters are blocked", () => {
+    const onValid = jest.fn();
+    const { result } = renderHook(() => useSeatClassInput(0, onValid));
+    act(() => {
+      result.current.handleChange({ target: { value: "abc" } } as any);
+    });
+    expect(onValid).not.toHaveBeenCalled();
+    expect(result.current.value).toBe("0");
+  });
+
+  test("invalid numeric range sets error", () => {
+    const onValid = jest.fn();
+    const { result } = renderHook(() => useSeatClassInput(0, onValid));
+    act(() => {
+      result.current.handleChange({ target: { value: "100" } } as any);
+    });
+    expect(onValid).not.toHaveBeenCalled();
+    expect(result.current.error).toBe(true);
+  });
+});

--- a/frontend/shared/hooks/useSeatClassInput.ts
+++ b/frontend/shared/hooks/useSeatClassInput.ts
@@ -1,0 +1,42 @@
+import { useState } from "react";
+
+export interface SeatClassInput {
+  value: string;
+  error: boolean;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBlur: () => void;
+}
+
+export function useSeatClassInput(
+  initial: number,
+  onValidChange: (value: number) => void,
+): SeatClassInput {
+  const [value, setValue] = useState(String(initial));
+  const [error, setError] = useState(false);
+
+  const validate = (val: string) => {
+    if (val === "") return false;
+    const num = parseInt(val, 10);
+    return !Number.isNaN(num) && num >= 0 && num <= 99;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    if (/[^0-9]/.test(val)) {
+      return; // block letters and decimals
+    }
+    setValue(val);
+    if (validate(val)) {
+      setError(false);
+      onValidChange(parseInt(val, 10));
+    } else {
+      setError(true);
+    }
+  };
+
+  const handleBlur = () => {
+    setError(!validate(value));
+  };
+
+  return { value, error, handleChange, handleBlur };
+}


### PR DESCRIPTION
## Summary
- document seat class input constraints (0-99, whole numbers)
- add backlog item for seat class validation rules
- validate seat class fields in `FlightTable`
- add `useSeatClassInput` hook with tests
- update component tests for new behaviour
- log task completion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68724551220c8329b2112a191621b09e