### PR TITLE
Update backlog cleanup for hyphen names

### DIFF
--- a/backend/internal/context/task_logger.py
+++ b/backend/internal/context/task_logger.py
@@ -123,6 +123,9 @@ def parse_done_tasks() -> set[str]:
             status = fields[3]
             if status == "✅ Done":
                 tasks.add(name)
+                trimmed = re.split(r"[\u2013-]", name, 1)[0].strip()
+                if trimmed and trimmed != name:
+                    tasks.add(trimmed)
     return tasks
 
 
@@ -134,10 +137,9 @@ def clean_backlog() -> None:
     done_normalized: set[str] = set()
     for name in done:
         done_normalized.add(name)
-        if "–" in name:
-            trimmed = name.split("–", 1)[0].strip()
-            if trimmed:
-                done_normalized.add(trimmed)
+        trimmed = re.split(r"[\u2013-]", name, 1)[0].strip()
+        if trimmed and trimmed != name:
+            done_normalized.add(trimmed)
 
     backlog_path = base / BACKLOG_FILE
     if not backlog_path.exists():

--- a/backend/internal/context/test_task_logger.py
+++ b/backend/internal/context/test_task_logger.py
@@ -40,6 +40,7 @@ def _setup_files(tmp_path: Path) -> None:
         "cleanup_done",
         "missing_files",
         "prefix_behavior",
+        "hyphen_cleanup",
     ],
 )
 def test_task_logger(tmp_path: Path, scenario: str) -> None:
@@ -113,5 +114,17 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
         )
         content = (tmp_path / "codex_task_tracker.md").read_text()
         assert "Parent – Child" in content
+
+    elif scenario == "hyphen_cleanup":
+        backlog = tmp_path / "backend" / "backlog.md"
+        backlog.write_text("### Codex Task: Hyphen\n")
+        tl.update_task_tracker(
+            "Hyphen-Child",
+            "context",
+            "✅ Done",
+            "Codex",
+            "notes",
+        )
+        assert backlog.read_text().strip() == ""
 
     tl.BASE_DIR = ""

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -27,4 +27,5 @@
 | IPC Bridge Documentation                                    | docs      | ✅ Done    | frontend    | PRD + TECH_SPEC for Python subprocess bridge           | 2025-07-12  | 2025-07-12  |
 | Update useProcessXLS types                                  | hooks     | ✅ Done    | frontend    | update hook to use Mode and Category types             | 2025-07-12  | 2025-07-12  |
 | Add runtime validation to useProcessXLS                     | hooks     | ✅ Done    | frontend    | runtime checks for Mode/Category enums                 | 2025-07-12  | 2025-07-12  |
+| Normalize backlog cleanup hyphen                           | context   | ✅ Done    | shared     | handle hyphen names in cleanup                         | 2025-07-12  | 2025-07-12  |
 | Document environment variables (.env.sample)               | docs      | ✅ Done    | frontend    | added env sample and README steps                     | 2025-07-12  | 2025-07-12  |

--- a/frontend/components/FlightTable.tsx
+++ b/frontend/components/FlightTable.tsx
@@ -13,10 +13,12 @@ export const FlightTable: React.FC<FlightTableProps> = ({ rows, onChange }) => {
     onValid: (val: number) => void;
     label: string;
   }> = ({ value, onValid, label }) => {
-    const { value: val, error, handleChange, handleBlur } = useSeatClassInput(
-      value,
-      onValid,
-    );
+    const {
+      value: val,
+      error,
+      handleChange,
+      handleBlur,
+    } = useSeatClassInput(value, onValid);
     return (
       <div>
         <input

--- a/frontend/utils/taskLogger.test.ts
+++ b/frontend/utils/taskLogger.test.ts
@@ -53,6 +53,20 @@ test("cleanBacklog removes prefixed tasks", async () => {
   expect(backlog.trim()).toBe("");
 });
 
+test("cleanBacklog removes tasks when tracker uses hyphen", async () => {
+  const backlogPath = path.join(tmp, "frontend", "backlog.md");
+  fs.writeFileSync(backlogPath, "### Codex Task: Hyphen\n");
+  await updateTaskTracker({
+    taskName: "Hyphen-Subtask",
+    layers: "context",
+    status: "✅ Done",
+    assignedTo: "Codex",
+    notes: "",
+  });
+  const backlog = fs.readFileSync(backlogPath, "utf8");
+  expect(backlog.trim()).toBe("");
+});
+
 test("updates existing row when task is logged twice", async () => {
   const logPath = path.join(tmp, "codex_task_tracker.md");
   jest.useFakeTimers().setSystemTime(new Date("2025-01-01"));

--- a/frontend/utils/taskLogger.ts
+++ b/frontend/utils/taskLogger.ts
@@ -64,11 +64,9 @@ async function cleanBacklog(): Promise<void> {
   const doneNormalized = new Set<string>();
   for (const name of doneTasks) {
     doneNormalized.add(name);
-    if (name.includes("–")) {
-      const trimmed = name.split("–", 1)[0].trim();
-      if (trimmed) {
-        doneNormalized.add(trimmed);
-      }
+    const trimmed = name.split(/[\u2013-]/, 1)[0].trim();
+    if (trimmed && trimmed !== name) {
+      doneNormalized.add(trimmed);
     }
   }
   const backlogPath = path.join(BASE_DIR, BACKLOG_FILE);
@@ -108,7 +106,12 @@ async function parseDoneTasks(): Promise<Set<string>> {
       const fields = line.split("|").map((f) => f.trim());
       if (fields.length < 7) continue;
       if (fields[3] === "✅ Done") {
-        tasks.add(fields[1]);
+        const name = fields[1];
+        tasks.add(name);
+        const trimmed = name.split(/[\u2013-]/, 1)[0].trim();
+        if (trimmed && trimmed !== name) {
+          tasks.add(trimmed);
+        }
       }
     }
   } catch {


### PR DESCRIPTION
## Summary
- normalize task names using en dash or hyphen when parsing done tasks
- apply normalization in backlog cleanup utilities
- test backlog cleanup for hyphenated tracker entries
- run Prettier formatting on FlightTable
- log task in codex tracker

## Testing
- `npx eslint frontend/utils/taskLogger.ts` *(fails: ESLint couldn't find config)*
- `black --check backend`
- `isort --check-only backend`
- `npx prettier -c "frontend/**/*.{ts,tsx}"`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687259a50980832984903d08961a1575