### PR TITLE
feat(hooks): add usePythonSubprocess

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -29,3 +29,4 @@
 | Add runtime validation to useProcessXLS                     | hooks     | ✅ Done    | frontend    | runtime checks for Mode/Category enums                 | 2025-07-12  | 2025-07-12  |
 | Normalize backlog cleanup hyphen                           | context   | ✅ Done    | shared     | handle hyphen names in cleanup                         | 2025-07-12  | 2025-07-12  |
 | Document environment variables (.env.sample)               | docs      | ✅ Done    | frontend    | added env sample and README steps                     | 2025-07-12  | 2025-07-12  |
+| Hook – usePythonSubprocess                                  | hooks     | ⏳ In Progress | frontend    | spawn Python subprocess with typed args              | 2025-07-12  | 2025-07-12  |

--- a/frontend/components/UploadFlow.ipc.integration.test.tsx
+++ b/frontend/components/UploadFlow.ipc.integration.test.tsx
@@ -1,0 +1,90 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ModeSelector, Mode, Category } from "./ModeSelector";
+import { UploadBox } from "./UploadBox";
+import { usePythonSubprocess } from "../shared/hooks/usePythonSubprocess";
+import { FlightRow } from "../shared/types/flight";
+import { FlightTable } from "./FlightTable";
+import { spawn } from "child_process";
+import { readFile } from "fs/promises";
+import { EventEmitter } from "events";
+
+jest.mock("child_process");
+jest.mock("fs/promises");
+
+const spawnMock = spawn as unknown as jest.Mock;
+const readFileMock = readFile as unknown as jest.Mock;
+
+function createChild() {
+  const child: any = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  return child;
+}
+
+function createFile(name: string) {
+  return new File(["data"], name, { type: "application/vnd.ms-excel" });
+}
+
+const rows: FlightRow[] = [
+  {
+    num_vol: "AF1",
+    depart: "CDG",
+    arrivee: "LHR",
+    imma: "A320",
+    sd_loc: "A",
+    sa_loc: "B",
+    j_class: 0,
+    y_class: 0,
+  },
+];
+
+const TestScreen: React.FC = () => {
+  const [mode, setMode] = React.useState<Mode>(Mode.PRECOMMANDES);
+  const [category, setCategory] = React.useState<Category>(Category.SALON);
+  const [data, setData] = React.useState<FlightRow[] | null>(null);
+  const [error, setError] = React.useState(false);
+  const run = usePythonSubprocess();
+
+  const handleUpload = async (file: File) => {
+    try {
+      const result = await run("in.xls", "out.json", { mode, category });
+      setData(result);
+    } catch {
+      setError(true);
+    }
+  };
+
+  return (
+    <div>
+      <ModeSelector
+        mode={mode}
+        category={category}
+        onChange={(m, c) => {
+          setMode(m);
+          setCategory(c);
+        }}
+      />
+      <UploadBox onUpload={handleUpload} />
+      {data && <FlightTable rows={data} onChange={() => {}} />}
+      {error && <p role="alert">Failed</p>}
+    </div>
+  );
+};
+
+test("ipc flow renders rows", async () => {
+  const child = createChild();
+  spawnMock.mockReturnValue(child);
+  readFileMock.mockResolvedValue(JSON.stringify(rows));
+  render(<TestScreen />);
+  fireEvent.click(screen.getByRole("button", { name: /Commandes Définitives/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Prestations à Bord/i }));
+  const input = screen.getByTestId("file-input");
+  fireEvent.change(input, { target: { files: [createFile("test.xls")] } });
+  child.emit("close", 0);
+  await waitFor(() => {
+    expect(screen.getByText("AF1")).toBeInTheDocument();
+  });
+});

--- a/frontend/shared/hooks/usePythonSubprocess.test.ts
+++ b/frontend/shared/hooks/usePythonSubprocess.test.ts
@@ -1,0 +1,118 @@
+import { usePythonSubprocess } from "./usePythonSubprocess";
+import { spawn } from "child_process";
+import { readFile } from "fs/promises";
+import { Mode, Category } from "../../components/ModeSelector";
+import { EventEmitter } from "events";
+import { FlightRow } from "../types/flight";
+
+jest.mock("child_process");
+jest.mock("fs/promises");
+
+const spawnMock = spawn as unknown as jest.Mock;
+const readFileMock = readFile as unknown as jest.Mock;
+
+type Child = EventEmitter & { stderr: EventEmitter; kill: jest.Mock };
+
+function createChild(): Child {
+  const child: Child = Object.assign(new EventEmitter(), {
+    stderr: new EventEmitter(),
+    kill: jest.fn(),
+  });
+  return child;
+}
+
+describe("usePythonSubprocess", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns parsed rows on success", async () => {
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const rows: FlightRow[] = [
+      {
+        num_vol: "AF1",
+        depart: "CDG",
+        arrivee: "LHR",
+        imma: "A320",
+        sd_loc: "A",
+        sa_loc: "B",
+        j_class: 0,
+        y_class: 0,
+      },
+    ];
+    readFileMock.mockResolvedValue(JSON.stringify(rows));
+
+    const run = usePythonSubprocess();
+    const promise = run("in.xls", "out.json", {
+      mode: Mode.COMMANDES,
+      category: Category.SALON,
+    });
+
+    child.emit("close", 0);
+
+    await expect(promise).resolves.toEqual(rows);
+    expect(spawnMock).toHaveBeenCalledWith("python", [
+      "main.py",
+      "--input",
+      "in.xls",
+      "--output",
+      "out.json",
+      "--mode",
+      "commandes",
+      "--category",
+      "salon",
+    ]);
+  });
+
+  it("rejects with stderr on failure", async () => {
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const run = usePythonSubprocess();
+    const promise = run("in.xls", "out.json", {
+      mode: Mode.COMMANDES,
+      category: Category.SALON,
+    });
+    child.stderr.emit("data", "bad");
+    child.emit("close", 1);
+    await expect(promise).rejects.toThrow("bad");
+  });
+
+  it("rejects on invalid JSON", async () => {
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    readFileMock.mockResolvedValue("not json");
+    const run = usePythonSubprocess();
+    const promise = run("in.xls", "out.json", {
+      mode: Mode.COMMANDES,
+      category: Category.SALON,
+    });
+    child.emit("close", 0);
+    await expect(promise).rejects.toThrow();
+  });
+
+  it("rejects on timeout", async () => {
+    jest.useFakeTimers();
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const run = usePythonSubprocess();
+    const promise = run("in.xls", "out.json", {
+      mode: Mode.COMMANDES,
+      category: Category.SALON,
+    });
+    jest.advanceTimersByTime(10000);
+    await expect(promise).rejects.toThrow("timeout");
+    expect(child.kill).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it("validates mode and category", async () => {
+    const run = usePythonSubprocess();
+    await expect(
+      run("in.xls", "out.json", { mode: "bad" as Mode, category: Category.SALON })
+    ).rejects.toThrow("Invalid mode");
+    await expect(
+      run("in.xls", "out.json", { mode: Mode.COMMANDES, category: "bad" as Category })
+    ).rejects.toThrow("Invalid category");
+  });
+});

--- a/frontend/shared/hooks/usePythonSubprocess.ts
+++ b/frontend/shared/hooks/usePythonSubprocess.ts
@@ -1,0 +1,71 @@
+import { spawn } from "child_process";
+import { readFile } from "fs/promises";
+import { Mode, Category } from "../../components/ModeSelector";
+import { FlightRow } from "../types/flight";
+
+export interface PythonFilters {
+  mode: Mode;
+  category: Category;
+}
+
+/**
+ * Launches the Python processing script with filters and returns parsed rows.
+ */
+export function usePythonSubprocess() {
+  return async (
+    inputFile: string,
+    outputFile: string,
+    filters: PythonFilters,
+  ): Promise<FlightRow[]> => {
+    if (!Object.values(Mode).includes(filters.mode)) {
+      throw new Error(`Invalid mode: ${filters.mode}`);
+    }
+    if (!Object.values(Category).includes(filters.category)) {
+      throw new Error(`Invalid category: ${filters.category}`);
+    }
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn("python", [
+        "main.py",
+        "--input",
+        inputFile,
+        "--output",
+        outputFile,
+        "--mode",
+        filters.mode,
+        "--category",
+        filters.category,
+      ]);
+
+      let stderr = "";
+      proc.stderr.on("data", (d) => {
+        stderr += String(d);
+      });
+
+      const timer = setTimeout(() => {
+        proc.kill();
+        reject(new Error("Process timeout"));
+      }, 10000);
+
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+
+      proc.on("close", async (code) => {
+        clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(stderr || `Process exited with code ${code}`));
+          return;
+        }
+        try {
+          const text = await readFile(outputFile, "utf8");
+          const data = JSON.parse(text) as FlightRow[];
+          resolve(data);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- implement `usePythonSubprocess` hook for launching the Python process
- cover `usePythonSubprocess` with unit tests
- add IPC integration test for upload flow
- track progress in `codex_task_tracker.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68726c49d90c8329a04fc1c458e1aa9f