### PR TITLE
Extend subprocess error test

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -30,3 +30,4 @@
 | Normalize backlog cleanup hyphen                            | context   | ✅ Done    | shared      | handle hyphen names in cleanup                         | 2025-07-12  | 2025-07-12  |
 | Document environment variables (.env.sample)                | docs      | ✅ Done    | frontend    | added env sample and README steps                      | 2025-07-12  | 2025-07-12  |
 | Hook – usePythonSubprocess                                  | hooks     | ✅ Done    | frontend    | spawn Python subprocess with typed args                | 2025-07-12  | 2025-07-12  |
+| Extend usePythonSubprocess.test error cases                 | hooks     | ✅ Done    | frontend    | add error and signal rejection tests                  | 2025-07-12  | 2025-07-12  |


### PR DESCRIPTION
## Summary
- add child process error and signal cases to `usePythonSubprocess.test.ts`
- mark tracker item as done

## Testing
- `npm install`
- `npx prettier -w frontend/shared/hooks/usePythonSubprocess.test.ts`
- `npx eslint frontend/shared/hooks/usePythonSubprocess.test.ts` *(fails: ESLint couldn't find config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687279cf77188329b3c56365a489771f