### PR TITLE
Update usePythonSubprocess JSDoc

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -31,3 +31,4 @@
 | Document environment variables (.env.sample)                | docs      | ✅ Done    | frontend    | added env sample and README steps                      | 2025-07-12  | 2025-07-12  |
 | Hook – usePythonSubprocess                                  | hooks     | ✅ Done    | frontend    | spawn Python subprocess with typed args                | 2025-07-12  | 2025-07-12  |
 | Extend usePythonSubprocess.test error cases                 | hooks     | ✅ Done    | frontend    | add error and signal rejection tests                  | 2025-07-12  | 2025-07-12  |
+| usePythonSubprocess JSDoc outputFile | hooks                     | ✅ Done        | frontend    | document JSON FlightRow array requirement | 2025-07-12 | 2025-07-12 |

--- a/frontend/backlog.md
+++ b/frontend/backlog.md
@@ -1,30 +1,5 @@
 # 🧩 Frontend Feature Backlog
 
-### 💻 Codex Task: Hook – usePythonSubprocess
-🧭 Context: frontend | shared
-📁 Platform: shared
-🎯 Objective: Spawn a backend Python subprocess with typed arguments and capture its structured output.
-🧩 Specs:
-- Params: `{ mode: Mode; category: Category }`
-- Mode and Category: strict union types
-- Behavior:
-  - Spawns a subprocess using a configured Python entrypoint
-  - Parses stdout (expecting JSON)
-  - Catches stderr or timeouts as error states
-- Return: `{ data?: T; error?: string; status: 'idle' | 'loading' | 'success' | 'error' }`
-- Environment: uses `NEXT_PUBLIC_API_BASE_URL` or fallback default
-- Fallback: Local mode stubbed with a mock response in test
-
-🧪 Tests:
-- ✅ Unit: mock `child_process.spawn` to test stdout, stderr, invalid JSON, timeouts
-- ✅ Validate typed input (Mode/Category enums only)
-- ✅ Integration: simulate call via upload flow with XLS file and assert parsed result
-- ✅ Ensure hook error boundary does not break app
-
---------------------------------
-
-## ✅ Epic: Flight File Ingestion & Filtering
-
 ### 💻 Codex Task: IPC Bridge - usePythonSubprocess()
 🧭 Context: frontend
 📁 Platform: web
@@ -66,24 +41,6 @@
 * Render all toggle states
 * Actions tab logs changes via `onChange` handler
 
-### 💻 Codex Task: Seat Class Validation
-🧭 Context: frontend
-📁 Platform: web
-🎯 Objective: Enforce numeric validation rules for `j_class` and `y_class`
-🧩 Specs:
-* Inputs min `0`, max `99`, step `1`
-* Letters or decimals blocked
-* Negative or >99 values show error with red border
-* Invalid fields prevent update until corrected
-🧪 Tests:
-* Typing `-1`, `abc`, `100` → error highlight
-* Typing `23`, `0`, `99` → valid
-* Blur triggers validation display
-* Error clears when corrected
-
---------------------------------
-
-## ✅ Epic: Generate PDF
 ### 💻 Codex Task: Submit PDF Data - useGeneratePDF()
 🧭 Context: frontend
 📁 Platform: web
@@ -151,6 +108,7 @@ export interface FlightRow {
 🧪 Tests:
 * Ensure baseURL works
 * Mocks usable for testing hooks
+
 
 
 

--- a/frontend/shared/hooks/usePythonSubprocess.ts
+++ b/frontend/shared/hooks/usePythonSubprocess.ts
@@ -9,7 +9,16 @@ export interface PythonFilters {
 }
 
 /**
- * Launches the Python processing script with filters and returns parsed rows.
+ * Launches the Python processing script with the given filters and parses the
+ * resulting data.
+ *
+ * `outputFile` must contain a JSON array of {@link FlightRow} objects in the
+ * following shape:
+ * `num_vol`, `depart`, `arrivee`, `imma`, `sd_loc`, `sa_loc`, `j_class`,
+ * `y_class`.
+ *
+ * For the full structure see
+ * `/docs/frontend/epic/1.Flight File Ingestion and Filtering/IPC Bridge/TECH_SPEC.md`.
  */
 export function usePythonSubprocess() {
   return async (


### PR DESCRIPTION
## Summary
- clarify outputFile requirements in usePythonSubprocess
- update task tracker
- clean backlog

## Testing
- `npx prettier --write frontend/shared/hooks/usePythonSubprocess.ts`
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68727c225d50832986a08a6c64092f99