### PR TITLE
Migrate fireEvent usages to userEvent

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -33,3 +33,4 @@
 | Extend usePythonSubprocess.test error cases                 | hooks     | ✅ Done    | frontend    | add error and signal rejection tests                  | 2025-07-12  | 2025-07-12  |
 | usePythonSubprocess JSDoc outputFile | hooks                     | ✅ Done        | frontend    | document JSON FlightRow array requirement | 2025-07-12 | 2025-07-12 |
 | Python error helper       | hooks                     | ✅ Done        | Codex       | improve subprocess error messages | 2025-07-12 | 2025-07-12 |
+| UserEvent migration       | ui                        | ✅ Done        | frontend    | replace fireEvent with userEvent | 2025-07-12 | 2025-07-12 |

--- a/frontend/components/FlightTable.test.tsx
+++ b/frontend/components/FlightTable.test.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { FlightTable } from "./FlightTable";
 import { FlightRow } from "../shared/types/flight";
@@ -30,11 +31,12 @@ describe("FlightTable", () => {
     expect(inputs).toHaveLength(2);
   });
 
-  test("onChange called with updated row", () => {
+  test("onChange called with updated row", async () => {
     const handle = jest.fn();
     render(<FlightTable rows={[baseRow]} onChange={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(input, { target: { value: "5" } });
+    await userEvent.clear(input);
+    await userEvent.type(input, "5");
     expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 5 });
   });
 
@@ -44,29 +46,32 @@ describe("FlightTable", () => {
     expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(0);
   });
 
-  test("invalid input shows error and blocks change", () => {
+  test("invalid input shows error and blocks change", async () => {
     const handle = jest.fn();
     render(<FlightTable rows={[baseRow]} onChange={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(input, { target: { value: "abc" } });
+    await userEvent.clear(input);
+    await userEvent.type(input, "abc");
     expect(handle).not.toHaveBeenCalled();
     expect(input).toHaveClass("border-red-500");
   });
 
-  test("values outside range show error", () => {
+  test("values outside range show error", async () => {
     render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
     const input = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(input, { target: { value: "100" } });
-    fireEvent.blur(input);
+    await userEvent.clear(input);
+    await userEvent.type(input, "100");
+    input.blur();
     expect(input).toHaveClass("border-red-500");
   });
 
-  test("valid input clears error", () => {
+  test("valid input clears error", async () => {
     const handle = jest.fn();
     render(<FlightTable rows={[baseRow]} onChange={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(input, { target: { value: "23" } });
-    fireEvent.blur(input);
+    await userEvent.clear(input);
+    await userEvent.type(input, "23");
+    input.blur();
     expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 23 });
     expect(input).not.toHaveClass("border-red-500");
   });

--- a/frontend/components/ModeSelector.test.tsx
+++ b/frontend/components/ModeSelector.test.tsx
@@ -1,10 +1,11 @@
 /** @jest-environment jsdom */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { ModeSelector, Mode, Category } from "./ModeSelector";
 
-test("clicking mode button triggers onChange", () => {
+test("clicking mode button triggers onChange", async () => {
   const handleChange = jest.fn();
   render(
     <ModeSelector
@@ -13,13 +14,13 @@ test("clicking mode button triggers onChange", () => {
       onChange={handleChange}
     />,
   );
-  fireEvent.click(
+  await userEvent.click(
     screen.getByRole("button", { name: /Commandes Définitives/i }),
   );
   expect(handleChange).toHaveBeenCalledWith(Mode.COMMANDES, Category.SALON);
 });
 
-test("clicking category button triggers onChange", () => {
+test("clicking category button triggers onChange", async () => {
   const handleChange = jest.fn();
   render(
     <ModeSelector
@@ -28,7 +29,9 @@ test("clicking category button triggers onChange", () => {
       onChange={handleChange}
     />,
   );
-  fireEvent.click(screen.getByRole("button", { name: /Prestations à Bord/i }));
+  await userEvent.click(
+    screen.getByRole("button", { name: /Prestations à Bord/i }),
+  );
   expect(handleChange).toHaveBeenCalledWith(
     Mode.PRECOMMANDES,
     Category.PRESTATIONS,

--- a/frontend/components/UploadBox.test.tsx
+++ b/frontend/components/UploadBox.test.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { UploadBox } from "./UploadBox";
 
@@ -14,32 +15,32 @@ function createFile(
   return file;
 }
 
-test("rejects wrong file types", () => {
+test("rejects wrong file types", async () => {
   const onUpload = jest.fn();
   render(<UploadBox onUpload={onUpload} />);
   const input = screen.getByTestId("file-input");
   const file = createFile("bad.txt", "text/plain");
-  fireEvent.change(input, { target: { files: [file] } });
-  expect(screen.getByRole("alert")).toHaveTextContent(
+  await userEvent.upload(input, file, { applyAccept: false });
+  expect(await screen.findByRole("alert")).toHaveTextContent(
     "Only .xls files are allowed",
   );
   expect(onUpload).not.toHaveBeenCalled();
 });
 
-test("show filename after selection", () => {
+test("show filename after selection", async () => {
   const onUpload = jest.fn();
   render(<UploadBox onUpload={onUpload} />);
   const input = screen.getByTestId("file-input");
   const file = createFile("ok.xls");
-  fireEvent.change(input, { target: { files: [file] } });
-  expect(screen.getByText("ok.xls")).toBeInTheDocument();
+  await userEvent.upload(input, file);
+  expect(await screen.findByText("ok.xls")).toBeInTheDocument();
 });
 
-test("triggers upload callback", () => {
+test("triggers upload callback", async () => {
   const onUpload = jest.fn();
   render(<UploadBox onUpload={onUpload} />);
   const input = screen.getByTestId("file-input");
   const file = createFile("ok.xls");
-  fireEvent.change(input, { target: { files: [file] } });
+  await userEvent.upload(input, file);
   expect(onUpload).toHaveBeenCalledWith(file);
 });

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import axios from "../shared/api/axios";
 import { ModeSelector, Mode, Category } from "./ModeSelector";
@@ -66,12 +67,14 @@ const TestScreen: React.FC = () => {
 test("valid flow renders rows", async () => {
   mockedPost.mockResolvedValue({ status: 200, data: rows });
   render(<TestScreen />);
-  fireEvent.click(
+  await userEvent.click(
     screen.getByRole("button", { name: /Commandes Définitives/i }),
   );
-  fireEvent.click(screen.getByRole("button", { name: /Prestations à Bord/i }));
+  await userEvent.click(
+    screen.getByRole("button", { name: /Prestations à Bord/i }),
+  );
   const input = screen.getByTestId("file-input");
-  fireEvent.change(input, { target: { files: [createFile("test.xls")] } });
+  await userEvent.upload(input, createFile("test.xls"));
   await waitFor(() => {
     expect(screen.getByText("AF1")).toBeInTheDocument();
   });
@@ -82,7 +85,7 @@ test("error response shows fallback", async () => {
   mockedPost.mockRejectedValue(new Error("bad"));
   render(<TestScreen />);
   const input = screen.getByTestId("file-input");
-  fireEvent.change(input, { target: { files: [createFile("test.xls")] } });
+  await userEvent.upload(input, createFile("test.xls"));
   await waitFor(() => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });

--- a/frontend/components/UploadFlow.ipc.integration.test.tsx
+++ b/frontend/components/UploadFlow.ipc.integration.test.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { ModeSelector, Mode, Category } from "./ModeSelector";
 import { UploadBox } from "./UploadBox";
@@ -79,10 +80,14 @@ test("ipc flow renders rows", async () => {
   spawnMock.mockReturnValue(child);
   readFileMock.mockResolvedValue(JSON.stringify(rows));
   render(<TestScreen />);
-  fireEvent.click(screen.getByRole("button", { name: /Commandes Définitives/i }));
-  fireEvent.click(screen.getByRole("button", { name: /Prestations à Bord/i }));
+  await userEvent.click(
+    screen.getByRole("button", { name: /Commandes Définitives/i }),
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: /Prestations à Bord/i }),
+  );
   const input = screen.getByTestId("file-input");
-  fireEvent.change(input, { target: { files: [createFile("test.xls")] } });
+  await userEvent.upload(input, createFile("test.xls"));
   child.emit("close", 0);
   await waitFor(() => {
     expect(screen.getByText("AF1")).toBeInTheDocument();

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.8",
     "jest": "^30.0.4",


### PR DESCRIPTION
## Summary
- update tests to use `userEvent` instead of `fireEvent`
- install `@testing-library/user-event`
- log `UserEvent migration` task as done

## Testing
- `npx eslint .` *(fails: couldn't find config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68728443ff5883299d7ae4457c7a275b