### PR TITLE
Implement 13-column task logging

### DIFF
--- a/backend/internal/context/test_task_logger.py
+++ b/backend/internal/context/test_task_logger.py
@@ -23,11 +23,8 @@ def _setup_files(tmp_path: Path) -> None:
         "🗂️ Codex Task Tracker (SDLC Phase View | Status: To do, In Progress,"
         " Done | Context: backend/frontend/... | Notes: Technical and"
         " functional documentation)\n\n"
-        "| **Task Title**                    | **Phase**                   |"  # noqa: E501
-        " **Status** | **Context** | **Notes** | **Created** | **Updated** |\n"  # noqa: E501
-        "| --------------------------------- | ---------------------------"  # noqa: E501
-        " | ---------- | ----------- | --------------------------------------------------------------"  # noqa: E501
-        " | ---------- | --------- |\n"  # noqa: E501
+        "| Context | Task Title | Phase | Status | Layer | Domain | Module | Epic | Feature | Description | Test Status | Created | Updated |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
     )
     tracker.write_text(header)
 
@@ -50,11 +47,12 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
 
     if scenario == "append_new":
         tl.update_task_tracker(
-            "TaskA",
-            "context",
-            "⏳ In Progress",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="TaskA",
+                phase="context",
+                status="⏳ In Progress",
+                description="notes",
+            )
         )
         text = (tmp_path / "codex_task_tracker.md").read_text()
         assert "TaskA" in text and "⏳ In Progress" in text
@@ -62,18 +60,20 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
 
     elif scenario == "update_existing":
         tl.update_task_tracker(
-            "Sample",
-            "context",
-            "⏳ In Progress",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="Sample",
+                phase="context",
+                status="⏳ In Progress",
+                description="notes",
+            )
         )
         tl.update_task_tracker(
-            "Sample",
-            "context",
-            "✅ Done",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="Sample",
+                phase="context",
+                status="✅ Done",
+                description="notes",
+            )
         )
         content = (tmp_path / "codex_task_tracker.md").read_text()
         assert content.count("Sample") == 1
@@ -84,21 +84,23 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
         backlog = tmp_path / "backend" / "backlog.md"
         backlog.write_text(backlog.read_text() + "### Codex Task: Another\n")
         tl.update_task_tracker(
-            "Another",
-            "context",
-            "✅ Done",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="Another",
+                phase="context",
+                status="✅ Done",
+                description="notes",
+            )
         )
         assert "Another" not in backlog.read_text()
 
     elif scenario == "missing_files":
         tl.update_task_tracker(
-            "Missing",
-            "context",
-            "⏳ In Progress",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="Missing",
+                phase="context",
+                status="⏳ In Progress",
+                description="notes",
+            )
         )
         assert (tmp_path / "codex_task_tracker.md").exists()
         assert not (tmp_path / "backend" / "backlog.md").exists()
@@ -106,11 +108,12 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
     elif scenario == "prefix_behavior":
         tl.append_subtask(
             "Parent",
-            "Child",
-            "context",
-            "✅ Done",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="Child",
+                phase="context",
+                status="✅ Done",
+                description="notes",
+            ),
         )
         content = (tmp_path / "codex_task_tracker.md").read_text()
         assert "Parent – Child" in content
@@ -119,11 +122,12 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
         backlog = tmp_path / "backend" / "backlog.md"
         backlog.write_text("### Codex Task: Hyphen\n")
         tl.update_task_tracker(
-            "Hyphen-Child",
-            "context",
-            "✅ Done",
-            "Codex",
-            "notes",
+            tl.TaskLogEntry(
+                task_name="Hyphen-Child",
+                phase="context",
+                status="✅ Done",
+                description="notes",
+            )
         )
         assert backlog.read_text().strip() == ""
 

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -34,3 +34,5 @@
 | frontend | usePythonSubprocess JSDoc outputFile | hooks | ✅ Done | - | - | usePythonSubprocess.ts | Flight File Ingestion & Filtering | IPC Developer Experience | document JSON FlightRow array requirement | - | 2025-07-12 | 2025-07-12 |
 | Codex | Python error helper | hooks | ✅ Done | - | - | buildPythonErrorMessage.ts | Flight File Ingestion & Filtering | IPC Error Handling | improve subprocess error messages | - | 2025-07-12 | 2025-07-12 |
 | frontend | UserEvent migration | ui | ✅ Done | - | - | UploadBox.test.tsx, ModeSelector.test.tsx | XLS Upload UX | UI Testing Consistency | replace fireEvent with userEvent | - | 2025-07-12 | 2025-07-12 |
+| Codex | Update task logger schemas | context | ✅ Done | - | - | internal.context & utils | Task logging | Codex Tracker | update python/typescript loggers for 13 fields | - | 2025-07-13 | 2025-07-13 |
+

--- a/frontend/utils/taskLogger.test.ts
+++ b/frontend/utils/taskLogger.test.ts
@@ -25,10 +25,9 @@ test("prefixes task with parent name", async () => {
   await updateTaskTracker(
     {
       taskName: "Child",
-      layers: "context",
+      phase: "context",
       status: "✅ Done",
-      assignedTo: "Codex",
-      notes: "notes",
+      description: "notes",
     },
     "Parent",
   );
@@ -42,10 +41,9 @@ test("cleanBacklog removes prefixed tasks", async () => {
   await updateTaskTracker(
     {
       taskName: "Part1",
-      layers: "context",
+      phase: "context",
       status: "✅ Done",
-      assignedTo: "Codex",
-      notes: "",
+      description: "",
     },
     "Sample",
   );
@@ -58,10 +56,9 @@ test("cleanBacklog removes tasks when tracker uses hyphen", async () => {
   fs.writeFileSync(backlogPath, "### Codex Task: Hyphen\n");
   await updateTaskTracker({
     taskName: "Hyphen-Subtask",
-    layers: "context",
+    phase: "context",
     status: "✅ Done",
-    assignedTo: "Codex",
-    notes: "",
+    description: "",
   });
   const backlog = fs.readFileSync(backlogPath, "utf8");
   expect(backlog.trim()).toBe("");
@@ -72,18 +69,16 @@ test("updates existing row when task is logged twice", async () => {
   jest.useFakeTimers().setSystemTime(new Date("2025-01-01"));
   await updateTaskTracker({
     taskName: "Dup",
-    layers: "context",
+    phase: "context",
     status: "⏳ In Progress",
-    assignedTo: "Codex",
-    notes: "first",
+    description: "first",
   });
   jest.setSystemTime(new Date("2025-01-02"));
   await updateTaskTracker({
     taskName: "Dup",
-    layers: "context",
+    phase: "context",
     status: "✅ Done",
-    assignedTo: "Codex",
-    notes: "second",
+    description: "second",
   });
   jest.useRealTimers();
   const lines = fs


### PR DESCRIPTION
## Summary
- extend backend and frontend task loggers to write 13-field rows
- update duplicate detection and backlog cleanup for new columns
- adjust related tests
- document update in Codex tracker

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873a2d4cd188329a541a023b018bc46