### PR TITLE
Remove category field from /process endpoint

### DIFF
--- a/backend/delivery/api_routes.py
+++ b/backend/delivery/api_routes.py
@@ -14,7 +14,6 @@ router = APIRouter()
 async def process(
     file: UploadFile = File(...),
     mode: Literal["commandes", "precommandes"] = Form(...),
-    category: Literal["salon", "prestations"] = Form(...),
 ) -> list[dict]:
     today = date.today()
     if not file.filename.endswith(".xls"):

--- a/backend/tests/test_process_endpoint.py
+++ b/backend/tests/test_process_endpoint.py
@@ -59,7 +59,7 @@ async def test_process_valid_commandes(
         response = await ac.post(
             "/process",
             files={"file": ("test.xls", file_obj, "application/vnd.ms-excel")},
-            data={"mode": "commandes", "category": "salon"},
+            data={"mode": "commandes"},
         )
     assert response.status_code == 200
     assert response.json() == [
@@ -87,7 +87,7 @@ async def test_invalid_file_type(monkeypatch: pytest.MonkeyPatch) -> None:
         response = await ac.post(
             "/process",
             files={"file": ("bad.txt", file_obj, "text/plain")},
-            data={"mode": "commandes", "category": "salon"},
+            data={"mode": "commandes"},
         )
     assert response.status_code == 400
     assert "Invalid file type" in response.text
@@ -117,7 +117,7 @@ async def test_missing_column_error(monkeypatch: pytest.MonkeyPatch) -> None:
         response = await ac.post(
             "/process",
             files={"file": ("test.xls", file_obj, "application/vnd.ms-excel")},
-            data={"mode": "commandes", "category": "salon"},
+            data={"mode": "commandes"},
         )
     assert response.status_code == 400
     assert "Missing column" in response.text
@@ -157,7 +157,7 @@ async def test_precommandes_filters_j_plus_2(
         response = await ac.post(
             "/process",
             files={"file": ("test.xls", file_obj, "application/vnd.ms-excel")},
-            data={"mode": "precommandes", "category": "salon"},
+            data={"mode": "precommandes"},
         )
     assert response.status_code == 200
     body = response.json()

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -36,3 +36,4 @@
 | frontend | UserEvent migration | ui | ✅ Done | - | - | UploadBox.test.tsx, ModeSelector.test.tsx | XLS Upload UX | UI Testing Consistency | replace fireEvent with userEvent | - | 2025-07-12 | 2025-07-12 |
 | Codex | Update task logger schemas | context | ✅ Done | - | - | internal.context & utils | Task logging | Codex Tracker | update python/typescript loggers for 13 fields | - | 2025-07-13 | 2025-07-13 |
 
+| backend | Drop category from /process | delivery | ✅ Done | delivery | flight | parse_filter | Data Handling | Flight Parsing | remove obsolete category field; update tests | pass | 2025-07-13 | 2025-07-13 |


### PR DESCRIPTION
## Summary
- update `/process` route to only accept `file` and `mode`
- adjust unit tests accordingly
- log task in tracker

## Testing
- `flake8 backend/delivery/api_routes.py backend/tests/test_process_endpoint.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873ec23da288329a5f3a6d0090e2eed