### PR TITLE
Implement FlightRow Pydantic model

### DIFF
--- a/backend/delivery/api_routes.py
+++ b/backend/delivery/api_routes.py
@@ -5,16 +5,22 @@ from typing import Literal
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
+from backend.domain import FlightRow
 from backend.usecase.process_flight_data import process_flight_data
 
 router = APIRouter()
 
 
-@router.post("/process")
+@router.post(
+    "/process",
+    response_model=list[FlightRow],
+    summary="Filter and return structured flights",
+    description="Parses XLS, filters by J+1 or J+2, returns formatted rows for pairing and layout.",
+)
 async def process(
     file: UploadFile = File(...),
     mode: Literal["commandes", "precommandes"] = Form(...),
-) -> list[dict]:
+) -> list[FlightRow]:
     today = date.today()
     if not file.filename.endswith(".xls"):
         raise HTTPException(status_code=400, detail="Invalid file type")

--- a/backend/domain/__init__.py
+++ b/backend/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Domain models used across backend layers."""
+
+from .models import FlightRow
+
+__all__ = ["FlightRow"]

--- a/backend/domain/models.py
+++ b/backend/domain/models.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class FlightRow(BaseModel):
+    """Structured flight data returned after XLS parsing."""
+
+    num_vol: str
+    depart: str
+    arrivee: str
+    imma: str
+    sd_loc: datetime
+    sa_loc: datetime
+    jc: int
+    yc: int

--- a/backend/repository/xls_parser.py
+++ b/backend/repository/xls_parser.py
@@ -5,6 +5,8 @@ from typing import BinaryIO
 
 import pandas as pd
 
+from backend.domain import FlightRow
+
 REQUIRED_COLUMNS = ["Num Vol", "Départ", "Arrivée", "Imma", "SD LOC", "SA LOC"]
 
 
@@ -12,7 +14,7 @@ def parse_and_filter_xls(
     file_stream: BinaryIO,
     mode: str,
     today: date,
-) -> list[dict]:
+) -> list[FlightRow]:
     """Load XLS stream and return rows matching the target date."""
     df = pd.read_excel(file_stream)
 
@@ -32,16 +34,18 @@ def parse_and_filter_xls(
 
     filtered = df[df["SD LOC"].dt.date == target]
 
-    result = []
+    result: list[FlightRow] = []
     for _, row in filtered.iterrows():
         result.append(
-            {
-                "num_vol": row["Num Vol"],
-                "depart": row["Départ"],
-                "arrivee": row["Arrivée"],
-                "imma": row["Imma"],
-                "sd_loc": row["SD LOC"],
-                "sa_loc": row["SA LOC"],
-            }
+            FlightRow(
+                num_vol=row["Num Vol"],
+                depart=row["Départ"],
+                arrivee=row["Arrivée"],
+                imma=row["Imma"],
+                sd_loc=row["SD LOC"],
+                sa_loc=row["SA LOC"],
+                jc=0,
+                yc=0,
+            )
         )
     return result

--- a/backend/tests/test_process_endpoint.py
+++ b/backend/tests/test_process_endpoint.py
@@ -70,6 +70,8 @@ async def test_process_valid_commandes(
             "imma": "F-1",
             "sd_loc": "2025-07-11T08:00:00",
             "sa_loc": "2025-07-11T12:00:00",
+            "jc": 0,
+            "yc": 0,
         }
     ]
 
@@ -163,3 +165,5 @@ async def test_precommandes_filters_j_plus_2(
     body = response.json()
     assert len(body) == 1
     assert body[0]["num_vol"] == "AF2"
+    assert body[0]["jc"] == 0
+    assert body[0]["yc"] == 0

--- a/backend/tests/test_xls_parser.py
+++ b/backend/tests/test_xls_parser.py
@@ -9,6 +9,8 @@ from typing import Any
 import pandas as pd
 import pytest
 
+from backend.domain import FlightRow
+
 MODULE_PATH = Path(__file__).parents[1] / "repository" / "xls_parser.py"
 spec = util.spec_from_file_location("xls_parser", MODULE_PATH)
 assert spec and spec.loader
@@ -48,7 +50,8 @@ def test_parse_commandes() -> None:
     file_obj = _make_xls(rows)
     result = parse_and_filter_xls(file_obj, "commandes", today)
     assert len(result) == 1
-    assert result[0]["num_vol"] == "AF1"
+    assert isinstance(result[0], FlightRow)
+    assert result[0].num_vol == "AF1"
 
 
 def test_parse_precommandes() -> None:
@@ -74,7 +77,8 @@ def test_parse_precommandes() -> None:
     file_obj = _make_xls(rows)
     result = parse_and_filter_xls(file_obj, "precommandes", today)
     assert len(result) == 1
-    assert result[0]["num_vol"] == "AF2"
+    assert isinstance(result[0], FlightRow)
+    assert result[0].num_vol == "AF2"
 
 
 def test_missing_column_error() -> None:

--- a/backend/usecase/process_flight_data.py
+++ b/backend/usecase/process_flight_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from typing import BinaryIO
 
+from backend.domain import FlightRow
 from backend.repository.xls_parser import parse_and_filter_xls
 
 
@@ -10,6 +11,6 @@ def process_flight_data(
     file_stream: BinaryIO,
     mode: str,
     today: date,
-) -> list[dict]:
+) -> list[FlightRow]:
     """Delegate XLS parsing and filtering to repository layer."""
     return parse_and_filter_xls(file_stream, mode, today)

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -37,3 +37,4 @@
 | Codex | Update task logger schemas | context | ✅ Done | - | - | internal.context & utils | Task logging | Codex Tracker | update python/typescript loggers for 13 fields | - | 2025-07-13 | 2025-07-13 |
 
 | backend | Drop category from /process | delivery | ✅ Done | delivery | flight | parse_filter | Data Handling | Flight Parsing | remove obsolete category field; update tests | pass | 2025-07-13 | 2025-07-13 |
+| backend | FlightRow domain model | domain | ✅ Done | domain | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | implement FlightRow model and refactor layers | pass | 2025-07-13 | 2025-07-13 |


### PR DESCRIPTION
## Summary
- add `FlightRow` schema in the backend domain layer
- use `FlightRow` across repository, usecase, and delivery layers
- update endpoint and parser tests to expect model fields
- log the work in `codex_task_tracker`

## Testing
- `black backend`
- `isort backend`
- `flake8 backend`
- `pylint backend`
- `mypy backend`
- `pytest --cov=backend`

------
https://chatgpt.com/codex/tasks/task_e_6873ee20ef3083298d8a7201a3f304ac