### PR TITLE
Add RowError & row edit hook

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -42,3 +42,4 @@
 | backend | Annotate process route | delivery | ✅ Done | delivery | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | add OpenAPI response model, summary, description | pass | 2025-07-13 | 2025-07-13 |
 | backend | Replace openpyxl writer in tests | tests | ✅ Done | - | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | use xlwt writer; assert jc/yc defaults | pass | 2025-07-13 | 2025-07-13 |
 | frontend | Export cleanBacklog for backlog maintenance | context | ✅ Done | - | - | - | - | - | export cleanBacklog and fix quoting | pass | 2025-07-14 | 2025-07-14 |
+| frontend | Flight Table UI – FlightTable | ui | ✅ Done | ui | flight | parse_filter | Flight Parsing Flow | Table View Renderer | refactor with patch hook + row errors | pass | 2025-07-14 | 2025-07-14 |

--- a/frontend/components/FlightTable.test.tsx
+++ b/frontend/components/FlightTable.test.tsx
@@ -4,7 +4,17 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { FlightTable } from "./FlightTable";
-import { FlightRow } from "../shared/types/flight";
+import { FlightRow, RowError } from "../shared/types/flight";
+import { useEditFlightRow } from "../shared/hooks/useEditFlightRow";
+
+jest.mock("../shared/hooks/useEditFlightRow");
+
+const mutateMock = jest.fn();
+(useEditFlightRow as jest.Mock).mockReturnValue({
+  mutate: mutateMock,
+  isLoading: false,
+  error: null,
+});
 
 describe("FlightTable", () => {
   const baseRow: FlightRow = {
@@ -19,36 +29,41 @@ describe("FlightTable", () => {
   };
 
   test("renders all columns", () => {
-    render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
+    render(<FlightTable data={[baseRow]} errors={[]} onEdit={() => {}} />);
     expect(screen.getByText("AF1")).toBeInTheDocument();
     expect(screen.getByDisplayValue("1")).toBeInTheDocument();
     expect(screen.getByDisplayValue("2")).toBeInTheDocument();
   });
 
   test("only j_class and y_class are editable", () => {
-    render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
+    render(<FlightTable data={[baseRow]} errors={[]} onEdit={() => {}} />);
     const inputs = screen.getAllByRole("spinbutton");
     expect(inputs).toHaveLength(2);
   });
 
-  test("onChange called with updated row", async () => {
+  test("onEdit called after PATCH", async () => {
     const handle = jest.fn();
-    render(<FlightTable rows={[baseRow]} onChange={handle} />);
+    mutateMock.mockResolvedValue({ ...baseRow, j_class: 5 });
+    render(<FlightTable data={[baseRow]} errors={[]} onEdit={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(input);
     await userEvent.type(input, "5");
+    expect(mutateMock).toHaveBeenCalledWith({
+      ...baseRow,
+      j_class: 5,
+    });
     expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 5 });
   });
 
   test("handles undefined numeric fields", () => {
     const row = { ...baseRow, j_class: undefined as unknown as number };
-    render(<FlightTable rows={[row]} onChange={() => {}} />);
+    render(<FlightTable data={[row]} errors={[]} onEdit={() => {}} />);
     expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(0);
   });
 
   test("invalid input shows error and blocks change", async () => {
     const handle = jest.fn();
-    render(<FlightTable rows={[baseRow]} onChange={handle} />);
+    render(<FlightTable data={[baseRow]} errors={[]} onEdit={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(input);
     await userEvent.type(input, "abc");
@@ -57,7 +72,7 @@ describe("FlightTable", () => {
   });
 
   test("values outside range show error", async () => {
-    render(<FlightTable rows={[baseRow]} onChange={() => {}} />);
+    render(<FlightTable data={[baseRow]} errors={[]} onEdit={() => {}} />);
     const input = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(input);
     await userEvent.type(input, "100");
@@ -67,12 +82,20 @@ describe("FlightTable", () => {
 
   test("valid input clears error", async () => {
     const handle = jest.fn();
-    render(<FlightTable rows={[baseRow]} onChange={handle} />);
+    mutateMock.mockResolvedValue({ ...baseRow, j_class: 23 });
+    render(<FlightTable data={[baseRow]} errors={[]} onEdit={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(input);
     await userEvent.type(input, "23");
     input.blur();
     expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 23 });
     expect(input).not.toHaveClass("border-red-500");
+  });
+
+  test("error rows get highlighted", () => {
+    const errors: RowError[] = [{ num_vol: "AF1", message: "bad" }];
+    render(<FlightTable data={[baseRow]} errors={errors} onEdit={() => {}} />);
+    const row = screen.getByText("AF1").closest("tr");
+    expect(row).toHaveClass("bg-red-50");
   });
 });

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -62,7 +62,7 @@ const TestScreen: React.FC = () => {
         }}
       />
       <UploadBox onUpload={handleUpload} />
-      {data && <FlightTable rows={data} onChange={() => {}} />}
+      {data && <FlightTable data={data} errors={[]} onEdit={() => {}} />}
       {error && <p role="alert">Failed</p>}
     </div>
   );

--- a/frontend/components/UploadFlow.ipc.integration.test.tsx
+++ b/frontend/components/UploadFlow.ipc.integration.test.tsx
@@ -69,7 +69,7 @@ const TestScreen: React.FC = () => {
         }}
       />
       <UploadBox onUpload={handleUpload} />
-      {data && <FlightTable rows={data} onChange={() => {}} />}
+      {data && <FlightTable data={data} errors={[]} onEdit={() => {}} />}
       {error && <p role="alert">Failed</p>}
     </div>
   );

--- a/frontend/shared/hooks/useEditFlightRow.test.ts
+++ b/frontend/shared/hooks/useEditFlightRow.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from "@testing-library/react";
+import axios from "../api/axios";
+import { useEditFlightRow } from "./useEditFlightRow";
+import { FlightRow } from "../types/flight";
+
+jest.mock("../api/axios");
+
+const patchMock = axios.patch as unknown as jest.Mock;
+
+describe("useEditFlightRow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("patches row and returns data", async () => {
+    const row: FlightRow = {
+      num_vol: "AF1",
+      depart: "",
+      arrivee: "",
+      imma: "",
+      sd_loc: "",
+      sa_loc: "",
+      j_class: 1,
+      y_class: 2,
+    };
+    patchMock.mockResolvedValue({ data: row });
+    const { result } = renderHook(() => useEditFlightRow());
+    await act(async () => {
+      const res = await result.current.mutate(row);
+      expect(res).toEqual(row);
+    });
+    expect(patchMock).toHaveBeenCalledWith("/process", {
+      num_vol: "AF1",
+      j_class: 1,
+      y_class: 2,
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error on failure", async () => {
+    const err = new Error("bad");
+    patchMock.mockRejectedValue(err);
+    const { result } = renderHook(() => useEditFlightRow());
+    await act(async () => {
+      await expect(
+        result.current.mutate({
+          num_vol: "X",
+          depart: "",
+          arrivee: "",
+          imma: "",
+          sd_loc: "",
+          sa_loc: "",
+          j_class: 0,
+          y_class: 0,
+        }),
+      ).rejects.toBe(err);
+    });
+    expect(result.current.error).toBe(err);
+  });
+});

--- a/frontend/shared/hooks/useEditFlightRow.ts
+++ b/frontend/shared/hooks/useEditFlightRow.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import axios from "../api/axios";
+import { FlightRow } from "../types/flight";
+
+export function useEditFlightRow() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mutate = async (row: FlightRow): Promise<FlightRow> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { data } = await axios.patch<FlightRow>("/process", {
+        num_vol: row.num_vol,
+        j_class: row.j_class,
+        y_class: row.y_class,
+      });
+      setIsLoading(false);
+      return data;
+    } catch (err) {
+      setIsLoading(false);
+      setError(err as Error);
+      throw err;
+    }
+  };
+
+  return { mutate, isLoading, error };
+}

--- a/frontend/shared/types/flight.ts
+++ b/frontend/shared/types/flight.ts
@@ -14,3 +14,8 @@ export interface FlightRow {
    */
   y_class: number;
 }
+
+export interface RowError {
+  num_vol: string; // or unique row identifier
+  message: string;
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "axios": "^1.10.0"
+    "axios": "^1.10.0",
+    "clsx": "^2.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `RowError` type
- implement `useEditFlightRow` hook for PATCH requests
- refactor `FlightTable` to call the new hook and show row errors
- update tests and integration points
- log task completion

## Testing
- `npm test`
- `npx eslint frontend/**/*.ts*` *(fails: ESLint couldn't find configuration)*
- `npx prettier -c "frontend/**/*.{ts,tsx}"`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6874e7625b0c8329be1056e8963dc0e3