### PR TITLE
Apply JC/YC capacity limits

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -45,3 +45,4 @@
 | frontend | Flight Table UI – FlightTable | ui | ✅ Done | ui | flight | parse_filter | Flight Parsing Flow | Table View Renderer | refactor with patch hook + row errors | pass | 2025-07-14 | 2025-07-14 |
 | frontend | usePythonSubprocess return object | hooks | ✅ Done | - | flight | parse_filter | Flight Parsing Flow | IPC Integration | promise resolves with stdout/stderr and exit code; update useProcessXLS | pass | 2025-07-14 | 2025-07-14 |
 | frontend | Debug subprocess error messages | hooks | ✅ Done | - | flight | parse_filter | Flight Parsing Flow | IPC Error Debug Mode | show stderr only in debugMode; extract helper | pass | 2025-07-14 | 2025-07-14 |
+| backend | JC/YC capacity clamp | repository | ✅ Done | repository | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | clamp seat counts per immatriculation | pass | 2025-07-14 | 2025-07-14 |


### PR DESCRIPTION
## Summary
- clamp JC/YC values by aircraft in `xls_parser`
- test that parser respects aircraft capacity
- update tracker

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `flake8 backend/repository/xls_parser.py backend/tests/test_xls_parser.py`
- `pylint backend/repository/xls_parser.py backend/tests/test_xls_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_68751da2e64c8329bc31a529fd4dcbd9