### PR TITLE
Implement return leg boost

### DIFF
--- a/backend/internal/context/test_task_logger.py
+++ b/backend/internal/context/test_task_logger.py
@@ -138,9 +138,11 @@ def test_task_logger(tmp_path: Path, scenario: str) -> None:
         backlog = tmp_path / "backend" / "backlog.md"
         backlog.write_text("### Codex Task: `Dash – Test`\n")
         with (tmp_path / "codex_task_tracker.md").open("a") as f:
-            f.write(
-                "| backend | Dash - Test | context | ✅ Done | - | - | - | - | - | - | - | 2025-01-01 | 2025-01-01 |\n"
+            row = (
+                "| backend | Dash - Test | context | ✅ Done | - | - | - | -"
+                " | - | - | 2025-01-01 | 2025-01-01 |\n"
             )
+            f.write(row)
         tl.clean_backlog()
         assert backlog.read_text().strip() == ""
 

--- a/backend/repository/xls_parser.py
+++ b/backend/repository/xls_parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import BinaryIO
+from typing import BinaryIO, Literal
 
 import pandas as pd
 
@@ -21,7 +21,7 @@ REQUIRED_COLUMNS = ["Num Vol", "Départ", "Arrivée", "Imma", "SD LOC", "SA LOC"
 
 def parse_and_filter_xls(
     file_stream: BinaryIO,
-    mode: str,
+    mode: Literal["commandes", "precommandes"],
     today: date,
 ) -> list[FlightRow]:
     """Load XLS stream and return rows matching the target date."""

--- a/backend/tests/test_xls_parser.py
+++ b/backend/tests/test_xls_parser.py
@@ -162,6 +162,46 @@ def test_pairing_sort_order() -> None:
     assert jc_yc[3][1:] == (0, 0)
 
 
+def test_return_leg_boost_special_airport() -> None:
+    today = date(2025, 7, 10)
+    rows = [
+        {
+            "Num Vol": "MD400",
+            "Départ": "SVB",
+            "Arrivée": "TNR",
+            "Imma": "5REJK",
+            "SD LOC": datetime(2025, 7, 11, 6, 0),
+            "SA LOC": datetime(2025, 7, 11, 8, 0),
+        }
+    ]
+    file_obj = _make_xls(rows)
+    result = parse_and_filter_xls(file_obj, "commandes", today)
+    assert len(result) == 1
+    r = result[0]
+    assert r.jc == 2
+    assert r.yc == 4
+
+
+def test_return_leg_boost_default_airport() -> None:
+    today = date(2025, 7, 10)
+    rows = [
+        {
+            "Num Vol": "MD401",
+            "Départ": "TLE",
+            "Arrivée": "TNR",
+            "Imma": "5REJK",
+            "SD LOC": datetime(2025, 7, 11, 12, 0),
+            "SA LOC": datetime(2025, 7, 11, 14, 0),
+        }
+    ]
+    file_obj = _make_xls(rows)
+    result = parse_and_filter_xls(file_obj, "commandes", today)
+    assert len(result) == 1
+    r = result[0]
+    assert r.jc == 2
+    assert r.yc == 2
+
+
 @pytest.mark.parametrize(
     "imma,jc_max,yc_max",
     [

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -46,3 +46,4 @@
 | frontend | usePythonSubprocess return object | hooks | ✅ Done | - | flight | parse_filter | Flight Parsing Flow | IPC Integration | promise resolves with stdout/stderr and exit code; update useProcessXLS | pass | 2025-07-14 | 2025-07-14 |
 | frontend | Debug subprocess error messages | hooks | ✅ Done | - | flight | parse_filter | Flight Parsing Flow | IPC Error Debug Mode | show stderr only in debugMode; extract helper | pass | 2025-07-14 | 2025-07-14 |
 | backend | JC/YC capacity clamp | repository | ✅ Done | repository | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | clamp seat counts per immatriculation | pass | 2025-07-14 | 2025-07-14 |
+| backend | Return leg class boost | repository | ✅ Done | repository | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | increment jc/yc for return legs | pass | 2025-07-14 | 2025-07-14 |


### PR DESCRIPTION
## Summary
- extend `parse_and_filter_xls` mode type annotation
- test JC/YC boost logic for return legs
- break long string in task logger tests
- record task completion

## Testing
- `flake8`
- `pylint backend | tail -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751fb831448329bbd43bc19f980fde