### PR TITLE
Fix return-leg clamp logic

### DIFF
--- a/backend/repository/xls_parser.py
+++ b/backend/repository/xls_parser.py
@@ -62,6 +62,8 @@ def parse_and_filter_xls(
     for _, row in ordered_df.iterrows():
         jc = 0
         yc = 0
+        jc_max, yc_max = CAPACITY_LIMITS.get(row["Imma"], (99, 99))
+
         if mode == "commandes" and row["Arrivée"] == "TNR":
             if row["Départ"] in {"SVB", "DIE", "NOS"}:
                 jc += 2
@@ -70,7 +72,6 @@ def parse_and_filter_xls(
                 jc += 2
                 yc += 2
 
-        jc_max, yc_max = CAPACITY_LIMITS.get(row["Imma"], (99, 99))
         jc = min(jc, jc_max)
         yc = min(yc, yc_max)
 

--- a/backend/tests/test_xls_parser.py
+++ b/backend/tests/test_xls_parser.py
@@ -231,3 +231,24 @@ def test_jc_yc_limits(imma: str, jc_max: int, yc_max: int) -> None:
     assert r.jc == min(2, jc_max)
     assert r.yc == min(4, yc_max)
     assert r.jc <= jc_max and r.yc <= yc_max
+
+
+def test_return_leg_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    today = date(2025, 7, 10)
+    rows = [
+        {
+            "Num Vol": "MD500",
+            "Départ": "SVB",
+            "Arrivée": "TNR",
+            "Imma": "5RMJF",
+            "SD LOC": datetime(2025, 7, 11, 6, 0),
+            "SA LOC": datetime(2025, 7, 11, 8, 0),
+        }
+    ]
+    file_obj = _make_xls(rows)
+    monkeypatch.setitem(xls_parser.CAPACITY_LIMITS, "5RMJF", (1, 1))
+    result = parse_and_filter_xls(file_obj, "commandes", today)
+    assert len(result) == 1
+    r = result[0]
+    assert r.jc == 1
+    assert r.yc == 1

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -47,3 +47,4 @@
 | frontend | Debug subprocess error messages | hooks | ✅ Done | - | flight | parse_filter | Flight Parsing Flow | IPC Error Debug Mode | show stderr only in debugMode; extract helper | pass | 2025-07-14 | 2025-07-14 |
 | backend | JC/YC capacity clamp | repository | ✅ Done | repository | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | clamp seat counts per immatriculation | pass | 2025-07-14 | 2025-07-14 |
 | backend | Return leg class boost | repository | ✅ Done | repository | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | increment jc/yc for return legs | pass | 2025-07-14 | 2025-07-14 |
+| backend | Return leg clamp enforcement | repository | ✅ Done | repository | flight | parse_filter | Offline XLS PDF Generator | Flight Parsing | clamp after boosts with min(value, max_capacity) | pass | 2025-07-14 | 2025-07-14 |


### PR DESCRIPTION
## Summary
- clamp return-leg boost results using `min` with aircraft capacity
- ensure capacity limits are respected in tests
- log completion in codex tracker

## Testing
- `flake8 backend/repository/xls_parser.py backend/tests/test_xls_parser.py`
- `pylint backend/repository/xls_parser.py backend/tests/test_xls_parser.py` *(fails: import-error, missing docstrings)*
- `mypy backend/repository/xls_parser.py backend/tests/test_xls_parser.py` *(fails: missing stubs)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68752362758c83298cadf3e9a265be3d