### PR TITLE
Add CLI for XLS parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Copy `.env.sample` to `.env` and adjust these values as needed.
 
 ---
 
+### CLI Usage
+
+Run the Python parser directly to output a JSON file:
+
+```bash
+python cli/main.py --input flights.xls --output flights.json --mode commandes --category salon
+```
+
+The JSON format matches the object array consumed by `usePythonSubprocess`.
+
+---
+
 ## 🛠 Tech Stack
 
 | Layer       | Tech                    |

--- a/backend/tests/test_cli_main.py
+++ b/backend/tests/test_cli_main.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import date, datetime, timedelta
+from io import BytesIO
+from pathlib import Path
+
+import xlwt
+
+from .xls_helper import assert_true_xls
+
+
+def _make_xls(rows: list[dict]) -> BytesIO:
+    workbook = xlwt.Workbook()
+    sheet = workbook.add_sheet("Sheet1")
+    if rows:
+        headers = list(rows[0].keys())
+        for col, header in enumerate(headers):
+            sheet.write(0, col, header)
+        date_style = xlwt.easyxf(num_format_str="YYYY-MM-DD HH:MM:SS")
+        for row_index, row in enumerate(rows, 1):
+            for col_index, header in enumerate(headers):
+                value = row.get(header)
+                if isinstance(value, datetime):
+                    sheet.write(row_index, col_index, value, date_style)
+                else:
+                    sheet.write(row_index, col_index, value)
+    buffer = BytesIO()
+    workbook.save(buffer)
+    buffer.seek(0)
+    assert_true_xls(buffer)
+    return buffer
+
+
+def test_cli_main_writes_json(tmp_path: Path) -> None:
+    today = date.today()
+    rows = [
+        {
+            "Num Vol": "AF1",
+            "Départ": "CDG",
+            "Arrivée": "JFK",
+            "Imma": "F-1",
+            "SD LOC": datetime.combine(
+                today + timedelta(days=1),
+                datetime.min.time(),
+            ),
+            "SA LOC": datetime.combine(
+                today + timedelta(days=1),
+                datetime.min.time(),
+            ),
+        }
+    ]
+    buf = _make_xls(rows)
+    input_path = tmp_path / "in.xls"
+    input_path.write_bytes(buf.getvalue())
+    output_path = tmp_path / "out.json"
+
+    result = subprocess.run(
+        [
+            "python",
+            "cli/main.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--mode",
+            "commandes",
+            "--category",
+            "salon",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    data = json.loads(output_path.read_text())
+    assert data[0]["num_vol"] == "AF1"

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,42 @@
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from backend.usecase.process_flight_data import \
+    process_flight_data  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parse XLS and output JSON")
+    parser.add_argument("--input", required=True, help="Path to .xls file")
+    parser.add_argument("--output", required=True, help="Path to JSON output")
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=["commandes", "precommandes"],
+        help="Filtering mode",
+    )
+    parser.add_argument(
+        "--category",
+        help="Unused category filter",
+        default="",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    with input_path.open("rb") as f:
+        rows = process_flight_data(f, args.mode, date.today())
+
+    payload = [r.model_dump(mode="json") for r in rows]
+    output_path.write_text(json.dumps(payload, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -57,3 +57,4 @@
 | backend | xls_format_correctness_test | tests | ✅ Done | tests | flight | parse_filter | Offline XLS PDF Generator | Test Utilities | ensure true .xls files used in tests | pass | 2025-07-14 | 2025-07-14 |
 | backend | Modify extract_task_title logic | context | ✅ Done | - | - | internal.context | Task logging | Codex Tracker | detect Task <number> headings | pass | 2025-07-14 | 2025-07-14 |
 | frontend | Modify extract_task_title logic | context | ✅ Done | - | - | utils | Task logging | Codex Tracker | detect Task <number> headings | pass | 2025-07-14 | 2025-07-14 |
+| backend | CLI parser main.py | context | ✅ Done | - | flight | parse_filter | Offline XLS PDF Generator | CLI Integration | Python CLI for parse+JSON output | pass | 2025-07-14 | 2025-07-14 |

--- a/frontend/shared/hooks/usePythonSubprocess.ts
+++ b/frontend/shared/hooks/usePythonSubprocess.ts
@@ -35,7 +35,7 @@ export function usePythonSubprocess(debugMode = false) {
 
     return new Promise((resolve, reject) => {
       const proc = spawn("python", [
-        "main.py",
+        "cli/main.py",
         "--input",
         inputFile,
         "--output",


### PR DESCRIPTION
## Summary
- implement `cli/main.py` for parsing XLS files
- spawn new script from `usePythonSubprocess`
- document usage in README
- add CLI unit test
- update codex task tracker

## Testing
- `flake8 .`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687546ac05408329af9819f4ae92b056