### PR TITLE
refactor(frontend): rename seat class fields to jc/yc

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -58,3 +58,4 @@
 | backend | Modify extract_task_title logic | context | ✅ Done | - | - | internal.context | Task logging | Codex Tracker | detect Task <number> headings | pass | 2025-07-14 | 2025-07-14 |
 | frontend | Modify extract_task_title logic | context | ✅ Done | - | - | utils | Task logging | Codex Tracker | detect Task <number> headings | pass | 2025-07-14 | 2025-07-14 |
 | backend | CLI parser main.py | context | ✅ Done | - | flight | parse_filter | Offline XLS PDF Generator | CLI Integration | Python CLI for parse+JSON output | pass | 2025-07-14 | 2025-07-14 |
+| frontend | Rename seat class fields to jc/yc | refactor | ✅ Done | shared | flight | parse_filter | Flight Parsing Flow | Seat Class Fields | rename j_class/y_class to jc/yc across frontend code, update docs | pass | 2025-07-14 | 2025-07-14 |

--- a/docs/flightRow.md
+++ b/docs/flightRow.md
@@ -13,14 +13,14 @@ export interface FlightRow {
   imma: string;
   sd_loc: string;
   sa_loc: string;
-  j_class: number;
-  y_class: number;
+  jc: number;
+  yc: number;
 }
 ```
 
 ## Editable Fields
 
-Only `j_class` and `y_class` are editable in the browser. All other fields are read-only values parsed from the `.xls` source.
+Only `jc` and `yc` are editable in the browser. All other fields are read-only values parsed from the `.xls` source.
 
 ### Seat Class Rules
 
@@ -33,14 +33,14 @@ Only `j_class` and `y_class` are editable in the browser. All other fields are r
 ## Column Mapping
 
 | Interface Field | Table Heading | Editable |
-| --------------- | ------------ | -------- |
-| `num_vol`       | Num Vol      | No       |
-| `depart`        | Départ       | No       |
-| `arrivee`       | Arrivée      | No       |
-| `imma`          | Imma         | No       |
-| `sd_loc`        | SD LOC       | No       |
-| `sa_loc`        | SA LOC       | No       |
-| `j_class`       | J/C          | Yes      |
-| `y_class`       | Y/C          | Yes      |
+| --------------- | ------------- | -------- |
+| `num_vol`       | Num Vol       | No       |
+| `depart`        | Départ        | No       |
+| `arrivee`       | Arrivée       | No       |
+| `imma`          | Imma          | No       |
+| `sd_loc`        | SD LOC        | No       |
+| `sa_loc`        | SA LOC        | No       |
+| `jc`            | J/C           | Yes      |
+| `yc`            | Y/C           | Yes      |
 
 When new fields are introduced by the backend, extend the interface and table accordingly. Optional fields should use `?` in the TypeScript definition.

--- a/docs/frontend/flight/ingestion_filtering/parse_filter/TECH_SPEC.frontend.md
+++ b/docs/frontend/flight/ingestion_filtering/parse_filter/TECH_SPEC.frontend.md
@@ -10,15 +10,15 @@ This document defines the technical implementation for the frontend bridge and U
 
 ## 🛡️ Modules
 
-| Module                       | Purpose                                                                    |
-| ---------------------------- | -------------------------------------------------------------------------- |
-| `UploadBox.tsx`              | File drop zone and mode/category UI                                        |
-| `useProcessXLS.ts`           | Frontend hook for invoking IPC bridge and validation                       |
-| `usePythonSubprocess.ts`     | IPC bridge for Python spawn process                                        |
-| `FlightTable.tsx`            | Tabular rendering of parsed data and editable class fields                 |
-| `AppContext.tsx`             | Global state (mode, category, flightRows, file)                            |
-| `shared/hooks/buildPythonErrorMessage.ts` | Transforms subprocess stderr to UI-facing error |
-| `useUploadFlow.ts`           | Orchestrates file upload through subprocess parsing and PATCH update chain |
+| Module                                    | Purpose                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------- |
+| `UploadBox.tsx`                           | File drop zone and mode/category UI                                        |
+| `useProcessXLS.ts`                        | Frontend hook for invoking IPC bridge and validation                       |
+| `usePythonSubprocess.ts`                  | IPC bridge for Python spawn process                                        |
+| `FlightTable.tsx`                         | Tabular rendering of parsed data and editable class fields                 |
+| `AppContext.tsx`                          | Global state (mode, category, flightRows, file)                            |
+| `shared/hooks/buildPythonErrorMessage.ts` | Transforms subprocess stderr to UI-facing error                            |
+| `useUploadFlow.ts`                        | Orchestrates file upload through subprocess parsing and PATCH update chain |
 
 ---
 
@@ -47,14 +47,14 @@ type FlightRow = {
   imma: string;
   sd_loc: string;
   sa_loc: string;
-  j_class?: string;
-  y_class?: string;
+  jc?: string;
+  yc?: string;
 };
 ```
 
 The Python script writes a JSON array to `outputFilePath` for later parsing.
 
-Editable fields `j_class` and `y_class` are supported via backend PATCH to `/process`. For seat-class validation rules, see [docs/flightRow.md](../../../../flightRow.md).
+Editable fields `jc` and `yc` are supported via backend PATCH to `/process`. For seat-class validation rules, see [docs/flightRow.md](../../../../flightRow.md).
 
 ---
 
@@ -69,8 +69,9 @@ Editable fields `j_class` and `y_class` are supported via backend PATCH to `/pro
 
 4. **FlightTable.tsx**:
    - Renders `FlightRow[]` with validation highlighting
-   - Provides inline editing of `j_class`, `y_class`
-   - Sends PATCH requests when locally edited
+
+- Provides inline editing of `jc`, `yc`
+- Sends PATCH requests when locally edited
 
 5. **AppContext.tsx**: Shares state across UploadBox, Table, and PDF Export modules.
 6. **useUploadFlow\.ts**:
@@ -101,8 +102,8 @@ const FlightRowSchema = z.object({
   imma: z.string(),
   sd_loc: z.string(),
   sa_loc: z.string(),
-  j_class: z.string().optional(),
-  y_class: z.string().optional(),
+  jc: z.string().optional(),
+  yc: z.string().optional(),
 });
 ```
 
@@ -118,7 +119,7 @@ const FlightRowSchema = z.object({
 
 ### PATCH Failures
 
-- If PATCH fails (e.g. editing `j_class` or `y_class`), an error icon is shown inline.
+- If PATCH fails (e.g. editing `jc` or `yc`), an error icon is shown inline.
 - Failed edits are not persisted or written to PDF export.
 
 ---
@@ -137,7 +138,7 @@ const FlightRowSchema = z.object({
 
 ## 📌 Notes
 
-- The editable behavior of `j_class` and `y_class` is now spec-compliant and synchronized with backend PATCH support.
+- The editable behavior of `jc` and `yc` is now spec-compliant and synchronized with backend PATCH support.
 - The IPC implementation is aligned with backend `PRD.md`/`TECH_SPEC.backend.md`.
 - A `.env.sample` file defines fallback output path and debug mode toggle.
 - All subprocess logic is abstracted to `usePythonSubprocess()` and NOT coupled with UI.
@@ -162,7 +163,7 @@ const FlightRowSchema = z.object({
 - **Behavior**:
   - Render table with error badges
   - Conditional row styling (invalid vs. valid)
-  - Inline editing for `j_class` and `y_class`
+  - Inline editing for `jc` and `yc`
   - Send PATCH requests on edit
 
 - **Routing**: none

--- a/frontend/components/FlightTable.test.tsx
+++ b/frontend/components/FlightTable.test.tsx
@@ -24,8 +24,8 @@ describe("FlightTable", () => {
     imma: "A320",
     sd_loc: "A",
     sa_loc: "B",
-    j_class: 1,
-    y_class: 2,
+    jc: 1,
+    yc: 2,
   };
 
   test("renders all columns", () => {
@@ -35,7 +35,7 @@ describe("FlightTable", () => {
     expect(screen.getByDisplayValue("2")).toBeInTheDocument();
   });
 
-  test("only j_class and y_class are editable", () => {
+  test("only jc and yc are editable", () => {
     render(<FlightTable data={[baseRow]} errors={[]} onEdit={() => {}} />);
     const inputs = screen.getAllByRole("spinbutton");
     expect(inputs).toHaveLength(2);
@@ -43,20 +43,20 @@ describe("FlightTable", () => {
 
   test("onEdit called after PATCH", async () => {
     const handle = jest.fn();
-    mutateMock.mockResolvedValue({ ...baseRow, j_class: 5 });
+    mutateMock.mockResolvedValue({ ...baseRow, jc: 5 });
     render(<FlightTable data={[baseRow]} errors={[]} onEdit={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(input);
     await userEvent.type(input, "5");
     expect(mutateMock).toHaveBeenCalledWith({
       ...baseRow,
-      j_class: 5,
+      jc: 5,
     });
-    expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 5 });
+    expect(handle).toHaveBeenCalledWith({ ...baseRow, jc: 5 });
   });
 
   test("handles undefined numeric fields", () => {
-    const row = { ...baseRow, j_class: undefined as unknown as number };
+    const row = { ...baseRow, jc: undefined as unknown as number };
     render(<FlightTable data={[row]} errors={[]} onEdit={() => {}} />);
     expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(0);
   });
@@ -82,13 +82,13 @@ describe("FlightTable", () => {
 
   test("valid input clears error", async () => {
     const handle = jest.fn();
-    mutateMock.mockResolvedValue({ ...baseRow, j_class: 23 });
+    mutateMock.mockResolvedValue({ ...baseRow, jc: 23 });
     render(<FlightTable data={[baseRow]} errors={[]} onEdit={handle} />);
     const input = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(input);
     await userEvent.type(input, "23");
     input.blur();
-    expect(handle).toHaveBeenCalledWith({ ...baseRow, j_class: 23 });
+    expect(handle).toHaveBeenCalledWith({ ...baseRow, jc: 23 });
     expect(input).not.toHaveClass("border-red-500");
   });
 

--- a/frontend/components/FlightTable.tsx
+++ b/frontend/components/FlightTable.tsx
@@ -94,9 +94,9 @@ export const FlightTable: React.FC<FlightTableProps> = ({
                 <td className="px-2 py-1">{r.sa_loc}</td>
                 <td className="px-2 py-1">
                   <SeatInput
-                    value={r.j_class ?? 0}
+                    value={r.jc ?? 0}
                     onValid={async (val) => {
-                      const patched = await mutate({ ...r, j_class: val });
+                      const patched = await mutate({ ...r, jc: val });
                       onEdit(patched);
                     }}
                     label={`J class for ${r.num_vol}`}
@@ -104,9 +104,9 @@ export const FlightTable: React.FC<FlightTableProps> = ({
                 </td>
                 <td className="px-2 py-1">
                   <SeatInput
-                    value={r.y_class ?? 0}
+                    value={r.yc ?? 0}
                     onValid={async (val) => {
-                      const patched = await mutate({ ...r, y_class: val });
+                      const patched = await mutate({ ...r, yc: val });
                       onEdit(patched);
                     }}
                     label={`Y class for ${r.num_vol}`}

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -30,8 +30,8 @@ const rows: FlightRow[] = [
     imma: "A320",
     sd_loc: "A",
     sa_loc: "B",
-    j_class: 0,
-    y_class: 0,
+    jc: 0,
+    yc: 0,
   },
 ];
 

--- a/frontend/components/UploadFlow.ipc.integration.test.tsx
+++ b/frontend/components/UploadFlow.ipc.integration.test.tsx
@@ -37,8 +37,8 @@ const rows: FlightRow[] = [
     imma: "A320",
     sd_loc: "A",
     sa_loc: "B",
-    j_class: 0,
-    y_class: 0,
+    jc: 0,
+    yc: 0,
   },
 ];
 

--- a/frontend/shared/hooks/useEditFlightRow.test.ts
+++ b/frontend/shared/hooks/useEditFlightRow.test.ts
@@ -21,8 +21,8 @@ describe("useEditFlightRow", () => {
       imma: "",
       sd_loc: "",
       sa_loc: "",
-      j_class: 1,
-      y_class: 2,
+      jc: 1,
+      yc: 2,
     };
     patchMock.mockResolvedValue({ data: row });
     const { result } = renderHook(() => useEditFlightRow());
@@ -32,8 +32,8 @@ describe("useEditFlightRow", () => {
     });
     expect(patchMock).toHaveBeenCalledWith("/process", {
       num_vol: "AF1",
-      j_class: 1,
-      y_class: 2,
+      jc: 1,
+      yc: 2,
     });
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
@@ -52,8 +52,8 @@ describe("useEditFlightRow", () => {
           imma: "",
           sd_loc: "",
           sa_loc: "",
-          j_class: 0,
-          y_class: 0,
+          jc: 0,
+          yc: 0,
         }),
       ).rejects.toBe(err);
     });

--- a/frontend/shared/hooks/useEditFlightRow.ts
+++ b/frontend/shared/hooks/useEditFlightRow.ts
@@ -12,8 +12,8 @@ export function useEditFlightRow() {
     try {
       const { data } = await axios.patch<FlightRow>("/process", {
         num_vol: row.num_vol,
-        j_class: row.j_class,
-        y_class: row.y_class,
+        jc: row.jc,
+        yc: row.yc,
       });
       setIsLoading(false);
       return data;

--- a/frontend/shared/hooks/useProcessXLS.test.ts
+++ b/frontend/shared/hooks/useProcessXLS.test.ts
@@ -16,9 +16,9 @@ jest.mock("./usePythonSubprocess", () => {
 });
 jest.mock("./buildPythonErrorMessage", () => ({
   buildPythonErrorMessage: jest.fn((...args) =>
-    jest.requireActual("./buildPythonErrorMessage").buildPythonErrorMessage(
-      ...args,
-    )
+    jest
+      .requireActual("./buildPythonErrorMessage")
+      .buildPythonErrorMessage(...args),
   ),
 }));
 jest.mock("fs/promises");
@@ -49,8 +49,8 @@ describe("useProcessXLS", () => {
         imma: "A320",
         sd_loc: "A",
         sa_loc: "B",
-        j_class: 0,
-        y_class: 0,
+        jc: 0,
+        yc: 0,
       },
     ];
     runMock.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
@@ -82,9 +82,7 @@ describe("useProcessXLS", () => {
     const processXLS = useProcessXLS();
     await expect(
       processXLS(new File([], "f.xls"), Mode.PRECOMMANDES, Category.SALON),
-    ).rejects.toThrow(
-      "Python subprocess failed to parse XLS: exit code 1",
-    );
+    ).rejects.toThrow("Python subprocess failed to parse XLS: exit code 1");
   });
 
   it("throws when JSON is invalid", async () => {
@@ -93,9 +91,7 @@ describe("useProcessXLS", () => {
     const processXLS = useProcessXLS();
     await expect(
       processXLS(new File([], "f.xls"), Mode.PRECOMMANDES, Category.SALON),
-    ).rejects.toThrow(
-      "Python subprocess failed to parse XLS: exit code 0",
-    );
+    ).rejects.toThrow("Python subprocess failed to parse XLS: exit code 0");
   });
 
   it("validates mode", async () => {

--- a/frontend/shared/types/flight.ts
+++ b/frontend/shared/types/flight.ts
@@ -8,11 +8,11 @@ export interface FlightRow {
   /**
    * Number of J class seats. Defaults to 0 when a row is created.
    */
-  j_class: number;
+  jc: number;
   /**
    * Number of Y class seats. Defaults to 0 when a row is created.
    */
-  y_class: number;
+  yc: number;
 }
 
 export interface RowError {


### PR DESCRIPTION
## Summary
- use `jc` and `yc` instead of `j_class` and `y_class`
- update docs to reference `jc` and `yc`
- rename seat class props across tests and components

## Testing
- `npx prettier -w frontend/shared/types/flight.ts frontend/shared/hooks/useEditFlightRow.ts frontend/shared/hooks/useEditFlightRow.test.ts frontend/shared/hooks/useProcessXLS.test.ts frontend/components/UploadFlow.ipc.integration.test.tsx frontend/components/UploadFlow.integration.test.tsx frontend/components/FlightTable.tsx frontend/components/FlightTable.test.tsx docs/flightRow.md docs/frontend/flight/ingestion_filtering/parse_filter/TECH_SPEC.frontend.md`
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68754c567fc8832991c60bb0fd60a9b4