### PR TITLE
Remove Category prop and enum

### DIFF
--- a/codex_task_tracker.md
+++ b/codex_task_tracker.md
@@ -60,3 +60,4 @@
 | backend | CLI parser main.py | context | ✅ Done | - | flight | parse_filter | Offline XLS PDF Generator | CLI Integration | Python CLI for parse+JSON output | pass | 2025-07-14 | 2025-07-14 |
 | frontend | Rename seat class fields to jc/yc | refactor | ✅ Done | shared | flight | parse_filter | Flight Parsing Flow | Seat Class Fields | rename j_class/y_class to jc/yc across frontend code, update docs | pass | 2025-07-14 | 2025-07-14 |
 | frontend | Seat edit local state | refactor | ✅ Done | ui | flight | parse_filter | Flight Parsing Flow | Table View Renderer | remove patch hook; manage seats locally | pass | 2025-07-14 | 2025-07-14 |
+| frontend | Remove Category from ModeSelector | refactor | ✅ Done | ui | flight | parse_filter | Flight Parsing Flow | Mode Selector Simplification | remove category enum and props | pass | 2025-07-14 | 2025-07-14 |

--- a/docs/frontend/flight/ingestion_filtering/parse_filter/TECH_SPEC.frontend.md
+++ b/docs/frontend/flight/ingestion_filtering/parse_filter/TECH_SPEC.frontend.md
@@ -12,11 +12,11 @@ This document defines the technical implementation for the frontend bridge and U
 
 | Module                                    | Purpose                                                    |
 | ----------------------------------------- | ---------------------------------------------------------- |
-| `UploadBox.tsx`                           | File drop zone and mode/category UI                        |
+| `UploadBox.tsx`                           | File drop zone and mode UI                                 |
 | `useProcessXLS.ts`                        | Frontend hook for invoking IPC bridge and validation       |
 | `usePythonSubprocess.ts`                  | IPC bridge for Python spawn process                        |
 | `FlightTable.tsx`                         | Tabular rendering of parsed data and editable class fields |
-| `AppContext.tsx`                          | Global state (mode, category, flightRows, file)            |
+| `AppContext.tsx`                          | Global state (mode, flightRows, file)                      |
 | `shared/hooks/buildPythonErrorMessage.ts` | Transforms subprocess stderr to UI-facing error            |
 | `useUploadFlow.ts`                        | Orchestrates file upload through subprocess parsing        |
 
@@ -32,7 +32,6 @@ interface XLSRequest {
   outputFilePath: string;
   filters: {
     mode: "arrivee" | "depart";
-    category: "commercial" | "militaire";
   };
 }
 ```
@@ -60,7 +59,7 @@ Editable fields `jc` and `yc` are managed locally. For seat-class validation rul
 
 ## ♻️ Flow
 
-1. **UploadBox.tsx**: Accepts `.xls` file + user inputs (`mode`, `category`).
+1. **UploadBox.tsx**: Accepts `.xls` file + user input (`mode`).
 2. **useProcessXLS.ts**: Validates inputs, invokes `usePythonSubprocess()`.
 3. **usePythonSubprocess.ts**:
    - Spawns Python subprocess via Tauri or Node bridge.
@@ -84,7 +83,7 @@ Editable fields `jc` and `yc` are managed locally. For seat-class validation rul
 
 ### Enum Guard
 
-Both `mode` and `category` undergo runtime validation before IPC is invoked:
+`mode` undergoes runtime validation before IPC is invoked:
 
 ```ts
 if (!["depart", "arrivee"].includes(mode)) throw new Error("Invalid mode");
@@ -119,13 +118,13 @@ const FlightRowSchema = z.object({
 
 ## 🧪 Tests
 
-| File                             | Tests                                                          |
-| -------------------------------- | -------------------------------------------------------------- |
-| `useProcessXLS.test.ts`          | Valid mode/category propagation, parse success, fallback error |
-| `usePythonSubprocess.test.ts`    | `.on('error')`, `.on('close')`, bad output file, invalid JSON  |
-| `UploadBox.integration.test.tsx` | Upload, mode/category selection, IPC output table rendering    |
-| `FlightTable.test.tsx`           | Seat class validation (0-99), editable fields                  |
-| `useUploadFlow.test.ts`          | Upload → parse → edit flow, edit state reconciliation          |
+| File                             | Tests                                                         |
+| -------------------------------- | ------------------------------------------------------------- |
+| `useProcessXLS.test.ts`          | Valid mode propagation, parse success, fallback error         |
+| `usePythonSubprocess.test.ts`    | `.on('error')`, `.on('close')`, bad output file, invalid JSON |
+| `UploadBox.integration.test.tsx` | Upload, mode selection, IPC output table rendering            |
+| `FlightTable.test.tsx`           | Seat class validation (0-99), editable fields                 |
+| `useUploadFlow.test.ts`          | Upload → parse → edit flow, edit state reconciliation         |
 
 ---
 

--- a/frontend/components/ModeSelector.test.tsx
+++ b/frontend/components/ModeSelector.test.tsx
@@ -3,55 +3,21 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ModeSelector, Mode, Category } from "./ModeSelector";
+import { ModeSelector, Mode } from "./ModeSelector";
 
 test("clicking mode button triggers onChange", async () => {
   const handleChange = jest.fn();
-  render(
-    <ModeSelector
-      mode={Mode.PRECOMMANDES}
-      category={Category.SALON}
-      onChange={handleChange}
-    />,
-  );
+  render(<ModeSelector mode={Mode.PRECOMMANDES} onChange={handleChange} />);
   await userEvent.click(
     screen.getByRole("button", { name: /Commandes Définitives/i }),
   );
-  expect(handleChange).toHaveBeenCalledWith(Mode.COMMANDES, Category.SALON);
-});
-
-test("clicking category button triggers onChange", async () => {
-  const handleChange = jest.fn();
-  render(
-    <ModeSelector
-      mode={Mode.PRECOMMANDES}
-      category={Category.SALON}
-      onChange={handleChange}
-    />,
-  );
-  await userEvent.click(
-    screen.getByRole("button", { name: /Prestations à Bord/i }),
-  );
-  expect(handleChange).toHaveBeenCalledWith(
-    Mode.PRECOMMANDES,
-    Category.PRESTATIONS,
-  );
+  expect(handleChange).toHaveBeenCalledWith(Mode.COMMANDES);
 });
 
 test("active classes match props", () => {
-  render(
-    <ModeSelector
-      mode={Mode.COMMANDES}
-      category={Category.PRESTATIONS}
-      onChange={() => {}}
-    />,
-  );
+  render(<ModeSelector mode={Mode.COMMANDES} onChange={() => {}} />);
   const commandes = screen.getByRole("button", {
     name: /Commandes Définitives/i,
   });
-  const prestations = screen.getByRole("button", {
-    name: /Prestations à Bord/i,
-  });
   expect(commandes.className).toMatch(/bg-blue-600/);
-  expect(prestations.className).toMatch(/bg-blue-600/);
 });

--- a/frontend/components/ModeSelector.tsx
+++ b/frontend/components/ModeSelector.tsx
@@ -6,32 +6,18 @@ export const Mode = {
 } as const;
 export type Mode = (typeof Mode)[keyof typeof Mode];
 
-export const Category = {
-  SALON: "salon",
-  PRESTATIONS: "prestations",
-} as const;
-export type Category = (typeof Category)[keyof typeof Category];
-
 export interface ModeSelectorProps {
   mode: Mode;
-  category: Category;
-  onChange: (mode: Mode, category: Category) => void;
+  onChange: (mode: Mode) => void;
 }
 
 export const ModeSelector: React.FC<ModeSelectorProps> = ({
   mode,
-  category,
   onChange,
 }) => {
   const handleMode = (next: Mode) => () => {
     if (next !== mode) {
-      onChange(next, category);
-    }
-  };
-
-  const handleCategory = (next: Category) => () => {
-    if (next !== category) {
-      onChange(mode, next);
+      onChange(next);
     }
   };
 
@@ -55,22 +41,6 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
           onClick={handleMode(Mode.COMMANDES)}
         >
           Commandes Définitives
-        </button>
-      </div>
-      <div role="group" aria-label="category" className="flex space-x-2">
-        <button
-          type="button"
-          className={`${base} ${category === Category.SALON ? active : inactive}`}
-          onClick={handleCategory(Category.SALON)}
-        >
-          Salon
-        </button>
-        <button
-          type="button"
-          className={`${base} ${category === Category.PRESTATIONS ? active : inactive}`}
-          onClick={handleCategory(Category.PRESTATIONS)}
-        >
-          Prestations à Bord
         </button>
       </div>
     </div>

--- a/frontend/components/UploadFlow.integration.test.tsx
+++ b/frontend/components/UploadFlow.integration.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ModeSelector, Mode, Category } from "./ModeSelector";
+import { ModeSelector, Mode } from "./ModeSelector";
 import { UploadBox } from "./UploadBox";
 import { useProcessXLS } from "../shared/hooks/useProcessXLS";
 import { FlightRow } from "../shared/types/flight";
@@ -37,14 +37,13 @@ const rows: FlightRow[] = [
 
 const TestScreen: React.FC = () => {
   const [mode, setMode] = React.useState<Mode>(Mode.PRECOMMANDES);
-  const [category, setCategory] = React.useState<Category>(Category.SALON);
   const [data, setData] = React.useState<FlightRow[] | null>(null);
   const [error, setError] = React.useState(false);
   const processXLS = useProcessXLS();
 
   const handleUpload = async (file: File) => {
     try {
-      const res = await processXLS(file, mode, category);
+      const res = await processXLS(file, mode);
       setData(res);
     } catch {
       setError(true);
@@ -55,10 +54,8 @@ const TestScreen: React.FC = () => {
     <div>
       <ModeSelector
         mode={mode}
-        category={category}
-        onChange={(m, c) => {
+        onChange={(m) => {
           setMode(m);
-          setCategory(c);
         }}
       />
       <UploadBox onUpload={handleUpload} />
@@ -73,9 +70,6 @@ test.skip("valid flow renders rows", async () => {
   render(<TestScreen />);
   await userEvent.click(
     screen.getByRole("button", { name: /Commandes Définitives/i }),
-  );
-  await userEvent.click(
-    screen.getByRole("button", { name: /Prestations à Bord/i }),
   );
   const input = screen.getByTestId("file-input");
   await userEvent.upload(input, createFile("test.xls"));

--- a/frontend/components/UploadFlow.ipc.integration.test.tsx
+++ b/frontend/components/UploadFlow.ipc.integration.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ModeSelector, Mode, Category } from "./ModeSelector";
+import { ModeSelector, Mode } from "./ModeSelector";
 import { UploadBox } from "./UploadBox";
 import { usePythonSubprocess } from "../shared/hooks/usePythonSubprocess";
 import { FlightRow } from "../shared/types/flight";
@@ -44,7 +44,6 @@ const rows: FlightRow[] = [
 
 const TestScreen: React.FC = () => {
   const [mode, setMode] = React.useState<Mode>(Mode.PRECOMMANDES);
-  const [category, setCategory] = React.useState<Category>(Category.SALON);
   const [data, setData] = React.useState<FlightRow[] | null>(null);
   const [error, setError] = React.useState(false);
   const run = usePythonSubprocess();
@@ -53,7 +52,6 @@ const TestScreen: React.FC = () => {
     try {
       const { exitCode, stderr } = await run("in.xls", "out.json", {
         mode,
-        category,
       });
       if (exitCode !== 0) throw new Error(stderr);
       const text = await readFile("out.json", "utf8");
@@ -67,10 +65,8 @@ const TestScreen: React.FC = () => {
     <div>
       <ModeSelector
         mode={mode}
-        category={category}
-        onChange={(m, c) => {
+        onChange={(m) => {
           setMode(m);
-          setCategory(c);
         }}
       />
       <UploadBox onUpload={handleUpload} />
@@ -87,9 +83,6 @@ test.skip("ipc flow renders rows", async () => {
   render(<TestScreen />);
   await userEvent.click(
     screen.getByRole("button", { name: /Commandes Définitives/i }),
-  );
-  await userEvent.click(
-    screen.getByRole("button", { name: /Prestations à Bord/i }),
   );
   const input = screen.getByTestId("file-input");
   await userEvent.upload(input, createFile("test.xls"));

--- a/frontend/shared/hooks/useProcessXLS.test.ts
+++ b/frontend/shared/hooks/useProcessXLS.test.ts
@@ -1,6 +1,6 @@
 import { useProcessXLS } from "./useProcessXLS";
 import { FlightRow } from "../types/flight";
-import { Mode, Category } from "../../components/ModeSelector";
+import { Mode } from "../../components/ModeSelector";
 import { usePythonSubprocess } from "./usePythonSubprocess";
 import { writeFile, readFile } from "fs/promises";
 import path from "path";
@@ -57,14 +57,13 @@ describe("useProcessXLS", () => {
     readFileMock.mockResolvedValue(JSON.stringify(rows));
     const processXLS = useProcessXLS();
     const file = new File(["data"], "f.xls");
-    const result = await processXLS(file, Mode.PRECOMMANDES, Category.SALON);
+    const result = await processXLS(file, Mode.PRECOMMANDES);
     const inputPath = path.join(tmpdir(), "input-1-f.xls");
     const outputPath = path.join(tmpdir(), "output-1.json");
     expect(result).toEqual(rows);
     expect(writeFileMock).toHaveBeenCalledWith(inputPath, expect.any(Buffer));
     expect(runMock).toHaveBeenCalledWith(inputPath, outputPath, {
       mode: Mode.PRECOMMANDES,
-      category: Category.SALON,
     });
   });
 
@@ -73,7 +72,7 @@ describe("useProcessXLS", () => {
     runMock.mockRejectedValue(error);
     const processXLS = useProcessXLS();
     await expect(
-      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES, Category.SALON),
+      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES),
     ).rejects.toBe(error);
   });
 
@@ -81,7 +80,7 @@ describe("useProcessXLS", () => {
     runMock.mockResolvedValue({ stdout: "", stderr: "bad", exitCode: 1 });
     const processXLS = useProcessXLS();
     await expect(
-      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES, Category.SALON),
+      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES),
     ).rejects.toThrow("Python subprocess failed to parse XLS: exit code 1");
   });
 
@@ -90,23 +89,15 @@ describe("useProcessXLS", () => {
     readFileMock.mockResolvedValue("not json");
     const processXLS = useProcessXLS();
     await expect(
-      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES, Category.SALON),
+      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES),
     ).rejects.toThrow("Python subprocess failed to parse XLS: exit code 0");
   });
 
   it("validates mode", async () => {
     const processXLS = useProcessXLS();
     await expect(
-      processXLS(new File([], "f.xls"), "bad" as Mode, Category.SALON),
+      processXLS(new File([], "f.xls"), "bad" as Mode),
     ).rejects.toThrow("Invalid mode");
-    expect(runMock).not.toHaveBeenCalled();
-  });
-
-  it("validates category", async () => {
-    const processXLS = useProcessXLS();
-    await expect(
-      processXLS(new File([], "f.xls"), Mode.PRECOMMANDES, "bad" as Category),
-    ).rejects.toThrow("Invalid category");
     expect(runMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/shared/hooks/useProcessXLS.ts
+++ b/frontend/shared/hooks/useProcessXLS.ts
@@ -2,7 +2,7 @@ import { writeFile, readFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { FlightRow } from "../types/flight";
-import { Mode, Category } from "../../components/ModeSelector";
+import { Mode } from "../../components/ModeSelector";
 import {
   usePythonSubprocess,
   PythonSubprocessResult,
@@ -14,21 +14,14 @@ import { buildPythonErrorMessage } from "./buildPythonErrorMessage";
  *
  * Example:
  * ```ts
- * const rows = await useProcessXLS()(file, Mode.PRECOMMANDES, Category.SALON);
+ * const rows = await useProcessXLS()(file, Mode.PRECOMMANDES);
  * ```
  */
 export function useProcessXLS() {
   const run = usePythonSubprocess();
-  return async (
-    file: File,
-    mode: Mode,
-    category: Category,
-  ): Promise<FlightRow[]> => {
+  return async (file: File, mode: Mode): Promise<FlightRow[]> => {
     if (!Object.values(Mode).includes(mode)) {
       throw new Error(`Invalid mode: ${mode}`);
-    }
-    if (!Object.values(Category).includes(category)) {
-      throw new Error(`Invalid category: ${category}`);
     }
 
     const timestamp = Date.now();
@@ -40,7 +33,6 @@ export function useProcessXLS() {
 
     const result: PythonSubprocessResult = await run(inputPath, outputPath, {
       mode,
-      category,
     });
 
     if (result.exitCode !== 0) {

--- a/frontend/shared/hooks/usePythonSubprocess.test.ts
+++ b/frontend/shared/hooks/usePythonSubprocess.test.ts
@@ -1,6 +1,6 @@
 import { usePythonSubprocess } from "./usePythonSubprocess";
 import { spawn } from "child_process";
-import { Mode, Category } from "../../components/ModeSelector";
+import { Mode } from "../../components/ModeSelector";
 import { EventEmitter } from "events";
 
 jest.mock("child_process");
@@ -34,7 +34,6 @@ describe("usePythonSubprocess", () => {
     const run = usePythonSubprocess();
     const promise = run("in.xls", "out.json", {
       mode: Mode.COMMANDES,
-      category: Category.SALON,
     });
 
     child.stdout.emit("data", "ok");
@@ -54,7 +53,6 @@ describe("usePythonSubprocess", () => {
     const run = usePythonSubprocess();
     const promise = run("in.xls", "out.json", {
       mode: Mode.COMMANDES,
-      category: Category.SALON,
     });
 
     child.stderr.emit("data", "bad\n");
@@ -71,7 +69,6 @@ describe("usePythonSubprocess", () => {
     const run = usePythonSubprocess(true);
     const promise = run("in.xls", "out.json", {
       mode: Mode.COMMANDES,
-      category: Category.SALON,
     });
 
     child.stderr.emit("data", "bad\n");
@@ -89,7 +86,6 @@ describe("usePythonSubprocess", () => {
     const run = usePythonSubprocess();
     const promise = run("in.xls", "out.json", {
       mode: Mode.COMMANDES,
-      category: Category.SALON,
     });
     jest.advanceTimersByTime(10000);
     await expect(promise).rejects.toThrow("timeout");
@@ -97,20 +93,13 @@ describe("usePythonSubprocess", () => {
     jest.useRealTimers();
   });
 
-  it("validates mode and category", async () => {
+  it("validates mode", async () => {
     const run = usePythonSubprocess();
     await expect(
       run("in.xls", "out.json", {
         mode: "bad" as Mode,
-        category: Category.SALON,
       }),
     ).rejects.toThrow("Invalid mode");
-    await expect(
-      run("in.xls", "out.json", {
-        mode: Mode.COMMANDES,
-        category: "bad" as Category,
-      }),
-    ).rejects.toThrow("Invalid category");
   });
 
   it("rejects when child emits error", async () => {
@@ -125,7 +114,6 @@ describe("usePythonSubprocess", () => {
     const err = new Error("boom");
     const promise = run("in.xls", "out.json", {
       mode: Mode.COMMANDES,
-      category: Category.SALON,
     });
     child.emit("error", err);
     await expect(promise).rejects.toBe(err);

--- a/frontend/shared/hooks/usePythonSubprocess.ts
+++ b/frontend/shared/hooks/usePythonSubprocess.ts
@@ -1,10 +1,9 @@
 import { spawn } from "child_process";
-import { Mode, Category } from "../../components/ModeSelector";
+import { Mode } from "../../components/ModeSelector";
 import { buildPythonErrorMessage } from "./buildPythonErrorMessage";
 
 export interface PythonFilters {
   mode: Mode;
-  category: Category;
 }
 
 /**
@@ -29,9 +28,6 @@ export function usePythonSubprocess(debugMode = false) {
     if (!Object.values(Mode).includes(filters.mode)) {
       throw new Error(`Invalid mode: ${filters.mode}`);
     }
-    if (!Object.values(Category).includes(filters.category)) {
-      throw new Error(`Invalid category: ${filters.category}`);
-    }
 
     return new Promise((resolve, reject) => {
       const proc = spawn("python", [
@@ -42,8 +38,6 @@ export function usePythonSubprocess(debugMode = false) {
         outputFile,
         "--mode",
         filters.mode,
-        "--category",
-        filters.category,
       ]);
 
       let stderr = "";


### PR DESCRIPTION
## Summary
- simplify ModeSelector to only track mode
- update hooks to remove category argument
- refactor associated tests
- document new interface in TECH_SPEC.frontend
- log task completion

## Testing
- `npx prettier -w frontend/components/ModeSelector.tsx frontend/components/ModeSelector.test.tsx frontend/components/UploadFlow.integration.test.tsx frontend/components/UploadFlow.ipc.integration.test.tsx frontend/shared/hooks/useProcessXLS.ts frontend/shared/hooks/useProcessXLS.test.ts frontend/shared/hooks/usePythonSubprocess.ts frontend/shared/hooks/usePythonSubprocess.test.ts docs/frontend/flight/ingestion_filtering/parse_filter/TECH_SPEC.frontend.md codex_task_tracker.md`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687552b359d08329b9cab7f1b2aadcdf